### PR TITLE
Fix import of Ans.Dpf.EngineeringData from Linux installer

### DIFF
--- a/src/ansys/dpf/composites/load_plugin.py
+++ b/src/ansys/dpf/composites/load_plugin.py
@@ -49,7 +49,7 @@ def load_composites_plugin(server: dpf.server, ansys_path: Optional[str] = None)
         },
         "Ans.Dpf.EngineeringData": {
             "nt": ["dpf", "bin", "winx64"],
-            "posix": ["dpf", "dll", "linx64"],
+            "posix": ["dpf", "bin", "linx64"],
         },
     }
 


### PR DESCRIPTION
The correct path looks like this
/usr/ansys_inc/v231/dpf/bin/linx64

Tested with Ubuntu 20.04
![image](https://user-images.githubusercontent.com/105842014/212777026-c39ae0bd-6a27-44b9-8b49-20f578e4ef3f.png)

![image](https://user-images.githubusercontent.com/105842014/212777091-7bb0f7f8-da79-4ae8-976c-ff6fed1120f4.png)
