### PR TITLE
Use 'PyDPF Composites' as HTML title

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,7 +27,7 @@ release = version = __version__
 html_logo = pyansys_logo_black
 html_favicon = ansys_favicon
 html_theme = "ansys_sphinx_theme"
-html_short_title = html_title = "pydpf-composites"
+html_short_title = html_title = "PyDPF Composites"
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).


### PR DESCRIPTION
Use the capitalized 'PyDPF Composites' instead of 'pydpf-composites' for the 'html_title' and 'html_short_title' in the documentation.

This is shown in the tab name, and the breadcrumbs.