### PR TITLE
More module name capitalization fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ For instance fatigue analysis. See `PyDPF Composites - Examples`_.
 Developer Setup
 ===============
 
-Installing Pydpf composites in developer mode allows
+Installing PyDPF Composites in developer mode allows
 you to modify the source and enhance it.
 
 Before contributing to the project, please refer to the `PyAnsys Developer's guide`_.

--- a/src/ansys/dpf/composites/_indexer.py
+++ b/src/ansys/dpf/composites/_indexer.py
@@ -31,7 +31,7 @@ def setup_index_by_id(scoping: Scoping) -> IndexToId:
     Parameters
     ----------
     scoping:
-        Dpf scoping
+        DPF scoping
     """
     indices: "NDArray[np.int64]" = np.full(max(scoping.ids) + 1, -1, dtype=np.int64)
     indices[scoping.ids] = np.arange(len(scoping.ids))

--- a/src/ansys/dpf/composites/layup_info/_add_layup_info_to_mesh.py
+++ b/src/ansys/dpf/composites/layup_info/_add_layup_info_to_mesh.py
@@ -20,9 +20,9 @@ def add_layup_info_to_mesh(
     Parameters
     ----------
     data_sources:
-        Dpf DataSources object available from CompositeModel: :class:`~CompositeModel.data_sources`
+        DPF DataSources object available from CompositeModel: :class:`~CompositeModel.data_sources`
     mesh:
-        Dpf MeshedRegion object available from CompositeModel: :class:`~CompositeModel.get_mesh`
+        DPF MeshedRegion object available from CompositeModel: :class:`~CompositeModel.get_mesh`
     material_operators:
        MaterialOperators object available from
        CompositeModel: :class:`~CompositeModel.material_operators`

--- a/src/ansys/dpf/composites/layup_info/_layup_info.py
+++ b/src/ansys/dpf/composites/layup_info/_layup_info.py
@@ -149,7 +149,7 @@ class AnalysisPlyInfoProvider:
     Parameters
     ----------
     mesh
-        Dpf MeshedRegion with layup information.
+        DPF MeshedRegion with layup information.
     name
         Analysis Ply Name
     """
@@ -185,9 +185,9 @@ def get_dpf_material_id_by_analyis_ply_map(
     Parameters
     ----------
     mesh
-        Dpf Meshed region enriched with layup information
+        DPF Meshed region enriched with layup information
     data_source_or_streams_provider:
-        Dpf data source with rst file or streams_provider. The streams provider is
+        DPF data source with rst file or streams_provider. The streams provider is
         available from :class:`~CompositeModel.core_model` (under metadata.streams_provider).
     """
     # Note: The stream_provider_or_data_source is not strictly needed for this workflow
@@ -235,7 +235,7 @@ def get_analysis_ply_index_to_name_map(
     Parameters
     ----------
     mesh
-        Dpf Meshed region enriched with layup information
+        DPF Meshed region enriched with layup information
     """
     analysis_ply_name_to_index_map = {}
     with mesh.property_field("layer_to_analysis_ply").as_local_field() as local_field:

--- a/src/ansys/dpf/composites/layup_info/material_properties.py
+++ b/src/ansys/dpf/composites/layup_info/material_properties.py
@@ -103,7 +103,7 @@ def get_constant_property(
         material property
     dpf_material_id:
     materials_provider:
-        Dpf Materials provider operator. Available from CompositeModel:
+        DPF Materials provider operator. Available from CompositeModel:
         :class:`CompositeModel.material_operators`
     data_source_or_streams_provider:
         Data source or streams provider that contains a rst file
@@ -136,9 +136,9 @@ def get_all_dpf_material_ids(
     Parameters
     ----------
     mesh:
-        Dpf MeshedRegion enriched with layup information
+        DPF MeshedRegion enriched with layup information
     data_source_or_streams_provider:
-        Dpf DataSource or StreamProvider that contains a rst file
+        DPF DataSource or StreamProvider that contains a rst file
     """
     id_to_material_map = get_dpf_material_id_by_analyis_ply_map(
         mesh, data_source_or_streams_provider
@@ -167,9 +167,9 @@ def get_constant_property_dict(
         Requested material properties
     materials_provider:
     data_source_or_streams_provider:
-        Dpf DataSource or StreamProvider that contains a rst file
+        DPF DataSource or StreamProvider that contains a rst file
     mesh:
-        Dpf MeshedRegion enriched with layup information
+        DPF MeshedRegion enriched with layup information
     """
     properties: Dict[np.int64, Dict[MaterialProperty, float]] = {}
     for dpf_material_id in get_all_dpf_material_ids(


### PR DESCRIPTION
* "Pydpf composites" ->"PyDPF Composites" in `README.rst`
* `Dpf` -> `DPF` in docstrings