### PR TITLE
Add missing newline after rst title

### DIFF
--- a/examples/dpf_composite_failure_workflow.py
+++ b/examples/dpf_composite_failure_workflow.py
@@ -3,6 +3,7 @@
 
 DPF composite failure workflow
 ------------------------------
+
 This example shows how to use the native DPF Python interface to configure
 and run the composite failure evaluator. It connects the different DPF
 operators that are needed to evaluate composite failure criteria.


### PR DESCRIPTION
Without the newline, sphinx-gallery skips the first paragraph when determining the hover tooltip.