### PR TITLE
Adapt to organization rename from 'pyansys' to 'ansys'

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -45,7 +45,7 @@ jobs:
     name: "Documentation style"
     runs-on: ubuntu-latest
     steps:
-      - uses: pyansys/actions/doc-style@v4
+      - uses: ansys/actions/doc-style@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: "Pull and start dpf container"
         run:  |
-          docker pull ghcr.io/pyansys/pydpf-composites:${{ env.CONTAINER_TAG }}
+          docker pull ghcr.io/ansys/pydpf-composites:${{ env.CONTAINER_TAG }}
 
       - name: "Checkout the project"
         uses: actions/checkout@v3
@@ -115,7 +115,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Pull and start DPF container"
         run: |
-          docker pull ghcr.io/pyansys/pydpf-composites:${{ env.CONTAINER_TAG }}
+          docker pull ghcr.io/ansys/pydpf-composites:${{ env.CONTAINER_TAG }}
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -150,8 +150,8 @@ jobs:
 
       - name: "Pull and start dpf container"
         run: |
-          docker pull ghcr.io/pyansys/pydpf-composites:${{ env.CONTAINER_TAG }}
-          docker run -d --restart always -p 21002:50052 -e ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }} -e ANSYS_DPF_ACCEPT_LA=Y ghcr.io/pyansys/pydpf-composites:${{ env.CONTAINER_TAG }}
+          docker pull ghcr.io/ansys/pydpf-composites:${{ env.CONTAINER_TAG }}
+          docker run -d --restart always -p 21002:50052 -e ANSYSLMD_LICENSE_FILE=1055@${{ secrets.LICENSE_SERVER }} -e ANSYS_DPF_ACCEPT_LA=Y ghcr.io/ansys/pydpf-composites:${{ env.CONTAINER_TAG }}
 
       - name: "Checkout the project"
         uses: actions/checkout@v3
@@ -198,7 +198,7 @@ jobs:
     needs: [doc-style, doc-build, code-style, tests, tests_minimal_version]
     steps:
       - name: "Build library source and wheel artifacts"
-        uses: pyansys/actions/build-library@v4
+        uses: ansys/actions/build-library@v4
         with:
           library-name: ${{ env.PACKAGE_NAME }}
 
@@ -212,7 +212,7 @@ jobs:
           python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - name: "Build a wheelhouse of the Python library"
-        uses: pyansys/actions/build-wheelhouse@v4
+        uses: ansys/actions/build-wheelhouse@v4
         with:
           library-name: "ansys-dpf-composites"
           library-namespace: "ansys.dpf.composites"
@@ -225,7 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-library, build-wheelhouse]
     steps:
-      - uses: pyansys/actions/doc-deploy-dev@v4
+      - uses: ansys/actions/doc-deploy-dev@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -239,14 +239,14 @@ jobs:
     steps:
 
       - name: "Release to the public PyPI repository"
-        uses: pyansys/actions/release-pypi-public@v4
+        uses: ansys/actions/release-pypi-public@v4
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           twine-username: "__token__"
           twine-token: ${{ secrets.PYPI_TOKEN }}
 
       - name: "Release to GitHub"
-        uses: pyansys/actions/release-github@v4
+        uses: ansys/actions/release-github@v4
         with:
           library-name: ${{ env.PACKAGE_NAME }}
 
@@ -256,7 +256,7 @@ jobs:
     needs: [release]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
     steps:
-      - uses: pyansys/actions/doc-deploy-stable@v4
+      - uses: ansys/actions/doc-deploy-stable@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -40,7 +40,7 @@ jobs:
     # Label based on branch name
     - uses: actions-ecosystem/action-add-labels@v1
       if: |
-        startsWith(github.event.pull_request.head.ref, 'doc') || 
+        startsWith(github.event.pull_request.head.ref, 'doc') ||
         startsWith(github.event.pull_request.head.ref, 'docs')
       with:
         labels: documentation
@@ -77,9 +77,9 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           Please add one of the following labels to add this contribution to the Release Notes :point_down:
-          - [bug](https://github.com/pyansys/pydpf-composites/pulls?q=label%3Abug+)
-          - [documentation](https://github.com/pyansys/pydpf-composites/pulls?q=label%3Adocumentation+)
-          - [enhancement](https://github.com/pyansys/pydpf-composites/pulls?q=label%3Aenhancement+)
-          - [good first issue](https://github.com/pyansys/pydpf-composites/pulls?q=label%3Agood+first+issue)
-          - [maintenance](https://github.com/pyansys/pydpf-composites/pulls?q=label%3Amaintenance+)
-          - [release](https://github.com/pyansys/pydpf-composites/pulls?q=label%3Arelease+)
+          - [bug](https://github.com/ansys/pydpf-composites/pulls?q=label%3Abug+)
+          - [documentation](https://github.com/ansys/pydpf-composites/pulls?q=label%3Adocumentation+)
+          - [enhancement](https://github.com/ansys/pydpf-composites/pulls?q=label%3Aenhancement+)
+          - [good first issue](https://github.com/ansys/pydpf-composites/pulls?q=label%3Agood+first+issue)
+          - [maintenance](https://github.com/ansys/pydpf-composites/pulls?q=label%3Amaintenance+)
+          - [release](https://github.com/ansys/pydpf-composites/pulls?q=label%3Arelease+)

--- a/.github/workflows/package_cleanup.yml
+++ b/.github/workflows/package_cleanup.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Delete untagged package versions"
-        uses: pyansys/actions/hk-package-clean-untagged@v4
+        uses: ansys/actions/hk-package-clean-untagged@v4
         with:
           package-name: 'pydpf-composites'
           allow-last-days: '14'

--- a/README.rst
+++ b/README.rst
@@ -16,12 +16,12 @@ PyDPF Composites
    :target: https://pypi.org/project/ansys-dpf-composites
    :alt: PyPI
 
-.. |codecov| image:: https://codecov.io/gh/pyansys/pydpf-composites/branch/main/graph/badge.svg
-   :target: https://codecov.io/gh/pyansys/pydpf-composites
+.. |codecov| image:: https://codecov.io/gh/ansys/pydpf-composites/branch/main/graph/badge.svg
+   :target: https://codecov.io/gh/ansys/pydpf-composites
    :alt: Codecov
 
-.. |GH-CI| image:: https://github.com/pyansys/pydpf-composites/actions/workflows/ci_cd.yml/badge.svg
-   :target: https://github.com/pyansys/pydpf-composites/actions/workflows/ci_cd.yml
+.. |GH-CI| image:: https://github.com/ansys/pydpf-composites/actions/workflows/ci_cd.yml/badge.svg
+   :target: https://github.com/ansys/pydpf-composites/actions/workflows/ci_cd.yml
    :alt: GH-CI
 
 .. |MIT| image:: https://img.shields.io/badge/License-MIT-yellow.svg
@@ -60,7 +60,7 @@ familiar with the `PyAnsys Developer's Guide`_.
 
     .. code:: bash
 
-        git clone https://github.com/pyansys/pydpf-composites
+        git clone https://github.com/ansys/pydpf-composites
         cd pydpf-composites
 
 
@@ -111,7 +111,7 @@ server is started.
 
     .. code:: bash
 
-        docker pull ghcr.io/pyansys/pydpf-composites:latest
+        docker pull ghcr.io/ansys/pydpf-composites:latest
         pytest .
 
 
@@ -147,8 +147,8 @@ On Windows, build documentation with this code:
 
 .. code:: bash
 
-    docker pull ghcr.io/pyansys/pydpf-composites:latest
-    docker run -d -p 21002:50052 -e ANSYSLMD_LICENSE_FILE=10555@mylicserver -e ANSYS_DPF_ACCEPT_LA=Y ghcr.io/pyansys/pydpf-composites:latest
+    docker pull ghcr.io/ansys/pydpf-composites:latest
+    docker run -d -p 21002:50052 -e ANSYSLMD_LICENSE_FILE=10555@mylicserver -e ANSYS_DPF_ACCEPT_LA=Y ghcr.io/ansys/pydpf-composites:latest
     tox -e doc-windows
 
 
@@ -156,8 +156,8 @@ On Linux, build documentation with this code:
 
 .. code:: bash
 
-    docker pull ghcr.io/pyansys/pydpf-composites:latest
-    docker run -d -p 21002:50052 -e ANSYSLMD_LICENSE_FILE=10555@mylicserver -e ANSYS_DPF_ACCEPT_LA=Y ghcr.io/pyansys/pydpf-composites:latest
+    docker pull ghcr.io/ansys/pydpf-composites:latest
+    docker run -d -p 21002:50052 -e ANSYSLMD_LICENSE_FILE=10555@mylicserver -e ANSYS_DPF_ACCEPT_LA=Y ghcr.io/ansys/pydpf-composites:latest
     tox -e doc-linux
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -37,7 +37,7 @@ add_module_names = True
 cname = os.environ.get("DOCUMENTATION_CNAME", "composites.dpf.docs.pyansys.com")
 
 html_theme_options = {
-    "github_url": "https://github.com/pyansys/pydpf-composites",
+    "github_url": "https://github.com/ansys/pydpf-composites",
     "show_prev_next": False,
     "show_breadcrumbs": True,
     "additional_breadcrumbs": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 authors = ["ANSYS, Inc. <ansys.support@ansys.com>"]
 maintainers = ["PyAnsys developers <pyansys.maintainers@ansys.com>"]
 readme = "README.rst"
-repository = "https://github.com/pyansys/pydpf-composites"
+repository = "https://github.com/ansys/pydpf-composites"
 documentation = "https://composites.dpf.docs.pyansys.com"
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/ansys/dpf/composites/example_helper/__init__.py
+++ b/src/ansys/dpf/composites/example_helper/__init__.py
@@ -15,7 +15,7 @@ from ..data_sources import (
     ShortFiberCompositesFiles,
 )
 
-EXAMPLE_REPO = "https://github.com/pyansys/example-data/raw/master/pydpf-composites/"
+EXAMPLE_REPO = "https://github.com/ansys/example-data/raw/master/pydpf-composites/"
 
 
 def upload_short_fiber_composite_files_to_server(

--- a/src/ansys/dpf/composites/server_helpers/_connect_to_or_start_server.py
+++ b/src/ansys/dpf/composites/server_helpers/_connect_to_or_start_server.py
@@ -30,7 +30,7 @@ def _wait_until_server_is_up(server: _dpf_server) -> Any:
     # Small hack to check if the server is up.
     # The DPF server should check this in the ``connect_to_server`` function, but
     # that's currently not the case.
-    # https://github.com/pyansys/pydpf-core/issues/414
+    # https://github.com/ansys/pydpf-core/issues/414
     # We use the fact that server.version throws an error if the server
     # is not yet connected.
     _try_until_timeout(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ class DockerProcess:
         process_out_file: pathlib.Path,
         process_err_file: pathlib.Path,
         license_server: str = "",
-        image_name: str = "ghcr.io/pyansys/pydpf-composites:latest",
+        image_name: str = "ghcr.io/ansys/pydpf-composites:latest",
         mount_directories: Mapping[str, str] = MappingProxyType({}),
     ):
         """Initialize the wrapper
@@ -329,7 +329,7 @@ def dpf_server(request: pytest.FixtureRequest):
 
     with start_server_process() as server_process:
         # Workaround for dpf bug. The timeout is not respected when connecting
-        # to a server:https://github.com/pyansys/pydpf-core/issues/638
+        # to a server:https://github.com/ansys/pydpf-core/issues/638
         # We just try until connect_to_server succeeds
         def start_server():
             if server_process.port:


### PR DESCRIPTION
Change the following references:
- `github.com/pyansys` -> `github.com/ansys`
- `ghcr.io/pyansys` -> `ghcr.io/ansys`
- `pyansys/actions` -> `ansys/actions`
- `https://codecov.io/gh/pyansys/pydpf-composites` -> `https://codecov.io/gh/ansys/pydpf-composites`