### PR TITLE
Test backward compatibility and add option to test any container

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -71,6 +71,7 @@ jobs:
       - name: "Pull and start dpf container"
         run:  |
           docker pull ghcr.io/ansys/pydpf-composites:${{ env.CONTAINER_TAG }}
+          docker pull ghcr.io/ansys/pydpf-composites:latest_2023r2
 
       - name: "Checkout the project"
         uses: actions/checkout@v3

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -73,7 +73,7 @@ jobs:
         # if other containers must be tested.
         run:  |
           docker pull ghcr.io/ansys/pydpf-composites:${{ env.CONTAINER_TAG }}
-          docker pull ghcr.io/ansys/pydpf-composites:latest_2023r2
+          docker pull ghcr.io/ansys/pydpf-composites:2023r2_pre1
 
       - name: "Checkout the project"
         uses: actions/checkout@v3

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -69,7 +69,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Pull pydpf container(s)"
-        # latest_2023r2 is used to test backward compatibility. Also update testenv in tox.ini
+        # 2023r2_pre1 is used to test backward compatibility. Also update testenv in tox.ini
         # if other containers must be tested.
         run:  |
           docker pull ghcr.io/ansys/pydpf-composites:${{ env.CONTAINER_TAG }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -68,7 +68,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Pull and start dpf container"
+      - name: "Pull pydpf container(s)"
+        # latest_2023r2 is used to test backward compatibility. Also update testenv in tox.ini
+        # if other containers must be tested.
         run:  |
           docker pull ghcr.io/ansys/pydpf-composites:${{ env.CONTAINER_TAG }}
           docker pull ghcr.io/ansys/pydpf-composites:latest_2023r2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,10 +53,10 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
     parser.addoption(
-       DOCKER_IMAGE_TAG_KEY,
-       action="store",
-       default="latest",
-       help="Tag of pydpf-composites container to start for the tests. Default is 'latest'.",
+        DOCKER_IMAGE_TAG_KEY,
+        action="store",
+        default="latest",
+        help="Tag of pydpf-composites container to start for the tests. Default is 'latest'.",
     )
 
 
@@ -103,14 +103,14 @@ class DockerProcess:
         return ServerContext(port=self.port, platform="linux", server=None)
 
     def __init__(
-            self,
-            server_out_file: pathlib.Path,
-            server_err_file: pathlib.Path,
-            process_out_file: pathlib.Path,
-            process_err_file: pathlib.Path,
-            license_server: str = "",
-            image_name: str = "",
-            mount_directories: Mapping[str, str] = MappingProxyType({}),
+        self,
+        server_out_file: pathlib.Path,
+        server_err_file: pathlib.Path,
+        process_out_file: pathlib.Path,
+        process_err_file: pathlib.Path,
+        license_server: str = "",
+        image_name: str = "",
+        mount_directories: Mapping[str, str] = MappingProxyType({}),
     ):
         """Initialize the wrapper
         Parameters
@@ -250,7 +250,9 @@ def dpf_server(request: pytest.FixtureRequest):
     docker_image_tag = request.config.getoption(DOCKER_IMAGE_TAG_KEY)
 
     active_options = [
-        option for option in [installer_path, running_server_port, docker_image_tag] if option is not None
+        option
+        for option in [installer_path, running_server_port, docker_image_tag]
+        if option is not None
     ]
 
     if len(active_options) > 1:
@@ -273,7 +275,7 @@ def dpf_server(request: pytest.FixtureRequest):
                 process_out_file=process_log_stdout,
                 process_err_file=process_log_stderr,
                 license_server=get_license_server_string(license_server_config),
-                image_name=image_name
+                image_name=image_name,
             )
 
     with start_server_process() as server_process:

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,8 @@ setenv =
     coverage: PYTEST_EXTRA_ARGS = --cov=ansys.dpf.composites --cov-report=term --cov-report=xml --cov-report=html
 commands =
     poetry install -E test
-    poetry run pytest --license-server={env:LICENSE_SERVER:} {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+    poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=latest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+    poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=latest_2023r2 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 
 [testenv:test-minimal]
 description = Checks for project unit tests with minimal package versions

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ setenv =
     coverage: PYTEST_EXTRA_ARGS = --cov=ansys.dpf.composites --cov-report=term --cov-report=xml --cov-report=html
 commands =
     poetry install -E test
+    poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=latest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
     poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=latest_2023r2 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 
 [testenv:test-minimal]

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ setenv =
 commands =
     poetry install -E test
     poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=latest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
-    poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=latest_2023r2 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+    poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=2023r2_pre1 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 
 [testenv:test-minimal]
 description = Checks for project unit tests with minimal package versions

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ setenv =
     coverage: PYTEST_EXTRA_ARGS = --cov=ansys.dpf.composites --cov-report=term --cov-report=xml --cov-report=html
 commands =
     poetry install -E test
-    poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=latest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
     poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=latest_2023r2 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 
 [testenv:test-minimal]


### PR DESCRIPTION
the docker images 2023 R2 and latest (2024 R1) are now tested by default to ensure backward compatibility. Jan and I have discussed that pydpf composites should support the last 2-3 versions of the backend.

However, the new option is a simple mechanism to test different versions of the container.