### PR TITLE
Set --cov-append on second pytest run in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,11 +26,13 @@ allowlist_externals  =
     poetry
 setenv =
     PYTHONUNBUFFERED = yes
-    coverage: PYTEST_EXTRA_ARGS = --cov=ansys.dpf.composites --cov-report=term --cov-report=xml --cov-report=html
+    coverage:
+        PYTEST_EXTRA_ARGS = --cov=ansys.dpf.composites --cov-report=term --cov-report=xml --cov-report=html
+        PYTEST_COV_APPEND_ARG = --cov-append
 commands =
     poetry install -E test
     poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=latest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
-    poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=2023r2_pre1 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+    poetry run pytest --license-server={env:LICENSE_SERVER:} --image-tag=2023r2_pre1 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
 
 [testenv:test-minimal]
 description = Checks for project unit tests with minimal package versions


### PR DESCRIPTION
Combine the coverage results by passing `--cov-append` on the second
`pytest` run in `tox.ini`.

The flag is not passed on the first run s.t. the coverage is properly reset when
developing locally.