### PR TITLE
Enable using distributed RST files for short fiber

### DIFF
--- a/examples/003_short_fiber_example.py
+++ b/examples/003_short_fiber_example.py
@@ -31,6 +31,7 @@ a short glass fiber reinforced thermoplastic injection molded from both sides.
 import ansys.dpf.core as dpf
 
 from ansys.dpf.composites.constants import FailureOutput
+from ansys.dpf.composites.data_sources import get_short_fiber_composites_data_sources
 from ansys.dpf.composites.example_helper import get_short_fiber_example_files
 from ansys.dpf.composites.server_helpers import connect_to_or_start_server
 
@@ -48,10 +49,7 @@ composite_files_on_server = get_short_fiber_example_files(server, "short_fiber")
 # Set up data sources
 # ~~~~~~~~~~~~~~~~~~~
 # Set up the data sources.
-data_sources = dpf.DataSources()
-data_sources.add_file_path(composite_files_on_server.engineering_data, "EngineeringData")
-data_sources.add_file_path(composite_files_on_server.dsdat, "dat")
-data_sources.set_result_file_path(composite_files_on_server.rst)
+data_sources = get_short_fiber_composites_data_sources(composite_files_on_server)
 
 # %%
 # Initialize DPF model

--- a/examples/009_short_fiber_orientation_tensor.py
+++ b/examples/009_short_fiber_orientation_tensor.py
@@ -27,6 +27,7 @@ import ansys.dpf.core as dpf
 import numpy as np
 from scipy.spatial.transform import Rotation
 
+from ansys.dpf.composites.data_sources import get_short_fiber_composites_data_sources
 from ansys.dpf.composites.example_helper import get_short_fiber_example_files
 from ansys.dpf.composites.server_helpers import connect_to_or_start_server
 
@@ -43,9 +44,7 @@ composite_files_on_server = get_short_fiber_example_files(server, "short_fiber")
 # Set up data sources
 # ~~~~~~~~~~~~~~~~~~~
 # Set up the data sources.
-data_sources = dpf.DataSources()
-data_sources.add_file_path(composite_files_on_server.dsdat, "dat")
-data_sources.set_result_file_path(composite_files_on_server.rst)
+data_sources = get_short_fiber_composites_data_sources(composite_files_on_server)
 
 # %%
 # Initialize DPF model

--- a/src/ansys/dpf/composites/data_sources.py
+++ b/src/ansys/dpf/composites/data_sources.py
@@ -15,6 +15,7 @@ __all__ = (
     "CompositeDataSources",
     "get_composite_files_from_workbench_result_folder",
     "get_composites_data_sources",
+    "get_short_fiber_composites_data_sources",
 )
 
 _SOLID_COMPOSITE_DEFINITIONS_PREFIX = "ACPSolidModel"
@@ -81,12 +82,41 @@ class ContinuousFiberCompositesFiles:
 class ShortFiberCompositesFiles:
     """Provides the container for short fiber composite file paths."""
 
-    rst: _PATH
+    rst: List[_PATH]
     dsdat: _PATH
     engineering_data: _PATH
     # True if files are local and false if files
     # have already been uploaded to the server
     files_are_local: bool = True
+
+    def __init__(
+        self,
+        rst: Union[List[_PATH], _PATH],
+        dsdat: _PATH,
+        engineering_data: _PATH,
+        files_are_local: bool = True,
+    ) -> None:
+        """Initialize the ShortFiberCompositesFiles container.
+
+        Parameters
+        ----------
+        rst :
+            A single path to an RST file, or a list of paths to distributed
+            RST files.
+        dsdat :
+            Path to the solver input file (``ds.dat``).
+        engineering_data :
+            Path to the engineering data file.
+        files_are_local :
+            True if files are on the local machine, False if they have already
+            been uploaded to the DPF server..
+        """
+        if isinstance(rst, (str, pathlib.Path)):
+            rst = [rst]
+        self.rst = rst  # type: ignore
+        self.dsdat = dsdat
+        self.engineering_data = engineering_data
+        self.files_are_local = files_are_local
 
 
 # roosre June 2023: refactor this class. Member composite should become
@@ -346,6 +376,23 @@ def get_composite_files_from_workbench_result_folder(
     return continuous_fiber_composite_files
 
 
+def _get_data_sources_from_rst_files(
+    rst_files: List[_PATH],
+) -> DataSources:
+    """Get a DPF data sources object from a list of RST files.
+
+    If a single RST file is provided, it is added via 'set_result_file_path'.
+    Otherwise, the RST files are added via 'set_domain_result_file_path'.
+    """
+    data_sources = DataSources()
+    if len(rst_files) == 1:
+        data_sources.set_result_file_path(rst_files[0])
+    else:
+        for idx, rst_file in enumerate(rst_files):
+            data_sources.set_domain_result_file_path(rst_file, idx)
+    return data_sources
+
+
 def get_composites_data_sources(
     continuous_composite_files: ContinuousFiberCompositesFiles,
 ) -> CompositeDataSources:
@@ -358,19 +405,19 @@ def get_composites_data_sources(
     if not continuous_composite_files.rst:
         raise RuntimeError("No rst files found.")
     else:
+        rst_data_source = _get_data_sources_from_rst_files(continuous_composite_files.rst)
+
         # NOTE: The 'material_support' is explicitly listed since it is currently not
         # supported (by the DPF Core) to use a distributed RST file as source for the
         # material support. Instead, we create a separate DataSources object for the
         # material support from the first RST file. This is a workaround until the
         # support for distributed RST is added.
-        material_support_data_source = DataSources()
-        material_support_data_source.set_result_file_path(continuous_composite_files.rst[0])
         if len(continuous_composite_files.rst) == 1:
-            rst_data_source = material_support_data_source
+            material_support_data_source = rst_data_source
         else:
-            rst_data_source = DataSources()
-            for idx, rst_file in enumerate(continuous_composite_files.rst):
-                rst_data_source.set_domain_result_file_path(rst_file, idx)
+            material_support_data_source = _get_data_sources_from_rst_files(
+                [continuous_composite_files.rst[0]]
+            )
 
     engineering_data_source = DataSources()
     engineering_data_source.add_file_path(
@@ -394,3 +441,20 @@ def get_composites_data_sources(
         composite=composite_data_sources,
         engineering_data=engineering_data_source,
     )
+
+
+def get_short_fiber_composites_data_sources(
+    short_fiber_composites_files: ShortFiberCompositesFiles,
+) -> DataSources:
+    """
+    Create DPF data sources from a ``ShortFiberCompositeFiles`` object.
+
+    Parameters
+    ----------
+    short_fiber_composite_files :
+        Container for short fiber composite file paths.
+    """
+    data_sources = _get_data_sources_from_rst_files(short_fiber_composites_files.rst)
+    data_sources.add_file_path(short_fiber_composites_files.dsdat, "dat")
+    data_sources.add_file_path(short_fiber_composites_files.engineering_data, "EngineeringData")
+    return data_sources

--- a/src/ansys/dpf/composites/example_helper/__init__.py
+++ b/src/ansys/dpf/composites/example_helper/__init__.py
@@ -32,7 +32,7 @@ class _ContinuousFiberCompositesExampleFilenames:
 
 @dataclass
 class _ShortFiberCompositesExampleFilenames:
-    rst: str
+    rst: List[str]
     dsdat: str
     engineering_data: str
 
@@ -124,7 +124,7 @@ _short_fiber_examples: Dict[str, _ShortFiberExampleLocation] = {
     "short_fiber": _ShortFiberExampleLocation(
         directory="short_fiber",
         files=_ShortFiberCompositesExampleFilenames(
-            rst="file.rst", engineering_data="MatML.xml", dsdat="ds.dat"
+            rst=["file.rst"], engineering_data="MatML.xml", dsdat="ds.dat"
         ),
     )
 }
@@ -169,7 +169,7 @@ def get_short_fiber_example_files(
             return _download_and_upload_file(example_files.directory, filename, tmpdir, server)
 
         return ShortFiberCompositesFiles(
-            rst=get_server_path(example_files.files.rst),
+            rst=[get_server_path(filename) for filename in example_files.files.rst],
             dsdat=get_server_path(example_files.files.dsdat),
             engineering_data=get_server_path(example_files.files.engineering_data),
             files_are_local=False,

--- a/src/ansys/dpf/composites/server_helpers/_upload_files_to_server.py
+++ b/src/ansys/dpf/composites/server_helpers/_upload_files_to_server.py
@@ -30,7 +30,7 @@ def upload_short_fiber_composite_files_to_server(
         return cast(str, dpf.upload_file_in_tmp_folder(filename, server=server))
 
     return ShortFiberCompositesFiles(
-        rst=upload(data_files.engineering_data),
+        rst=[upload(filename) for filename in data_files.rst],
         dsdat=upload(data_files.dsdat),
         engineering_data=upload(data_files.engineering_data),
         files_are_local=False,


### PR DESCRIPTION
Use a list of paths instead of a single path in the ShortFiberCompositesFiles class.

Add a helper function 'get_short_fiber_composites_data_sources' to directly obtain the DPF DataSources object from a 'ShortFiberCompositesFiles' object.