### PR TITLE
Implement simplified plugin load

### DIFF
--- a/src/ansys/dpf/composites/server_helpers/_load_plugin.py
+++ b/src/ansys/dpf/composites/server_helpers/_load_plugin.py
@@ -89,7 +89,6 @@ def load_composites_plugin(server: BaseServer, ansys_path: Optional[str] = None)
         possible_awp_roots = [
             "/ansys_inc/ansys/dpf/server_2023_2_pre1",
             "/ansys_inc/ansys/dpf/server_2023_2_pre2",
-            "/ansys_inc/ansys/dpf/server_2024_1_pre0",
         ]
 
         while True:

--- a/src/ansys/dpf/composites/server_helpers/_load_plugin.py
+++ b/src/ansys/dpf/composites/server_helpers/_load_plugin.py
@@ -10,6 +10,8 @@ from ansys.dpf.gate.errors import DPFServerException
 
 from ._versions import version_older_than
 
+# The automatic load of the plug-in can be disabled by the user and so
+# all plugins which are required for dpf composites are loaded
 _PLUGINS = (
     "Ans.Dpf.Native",
     "mapdlOperatorsCore",
@@ -24,8 +26,6 @@ def _load_plugins(
     awp_root_docker: str,
     ansys_path: Optional[str] = None,
 ) -> None:
-    # The automatic load of the plug-in can be disabled by the user and so
-    # all plugins which are required for dpf composites are loaded
     def get_lib_from_name(name: str) -> str:
         if server.os == "posix":
             return f"lib{name}.so"

--- a/src/ansys/dpf/composites/server_helpers/_load_plugin.py
+++ b/src/ansys/dpf/composites/server_helpers/_load_plugin.py
@@ -8,22 +8,24 @@ from ansys.dpf.core.misc import get_ansys_path
 from ansys.dpf.core.server_types import BaseServer
 from ansys.dpf.gate.errors import DPFServerException
 
+from ._versions import version_older_than
+
+_PLUGINS = (
+    "Ans.Dpf.Native",
+    "mapdlOperatorsCore",
+    "Ans.Dpf.FEMutils",
+    "Ans.Dpf.EngineeringData",
+    "composite_operators",
+)
+
 
 def _load_plugins(
     server: BaseServer,
     awp_root_docker: str,
     ansys_path: Optional[str] = None,
 ) -> None:
-    # The automatic load of the plug can be disabled by the user and so
+    # The automatic load of the plug-in can be disabled by the user and so
     # all plugins which are required for dpf composites are loaded
-    libs = [
-        "Ans.Dpf.Native",
-        "mapdlOperatorsCore",
-        "Ans.Dpf.FEMutils",
-        "Ans.Dpf.EngineeringData",
-        "composite_operators",
-    ]
-
     def get_lib_from_name(name: str) -> str:
         if server.os == "posix":
             return f"lib{name}.so"
@@ -50,7 +52,7 @@ def _load_plugins(
     if not ansys_path:
         raise RuntimeError("Ansys path is not available. DPF Composites plugin cannot be loaded.")
 
-    for name in libs:
+    for name in _PLUGINS:
         if name in location_in_installer:
             relative_location = location_in_installer[name][server.os]
             library = os.path.join(ansys_path, *relative_location, get_lib_from_name(name))
@@ -75,25 +77,35 @@ def load_composites_plugin(server: BaseServer, ansys_path: Optional[str] = None)
         Ans.Dpf.EngineeringData plugins are loaded from their location
         in the installer.
     """
-    # March 2023 R.Roos
-    # the dpf load_plugin method requires an absolute path because the dpf_composites
-    # plugin is not in the search path. The logic below should support all cases
-    # except a local gRPC sever on linux (local in-process server on Linux is supported)
-    # DPF core team thinks about to expose ANSYS_ROOT_FOLDER so that the absolute path
-    # can be easily constructed here.
-    # Different versions have different awp roots. Here we just try to load the plugins
-    # from different roots.
-    possible_awp_roots = [
-        "/ansys_inc/ansys/dpf/server_2023_2_pre1",
-        "/ansys_inc/ansys/dpf/server_2023_2_pre2",
-        "/ansys_inc/ansys/dpf/server_2024_1_pre0",
-    ]
+    if version_older_than(server, "7.0"):
+        # March 2023 R.Roos
+        # the dpf load_plugin method requires an absolute path because the dpf_composites
+        # plugin is not in the search path. The logic below should support all cases
+        # except a local gRPC sever on linux (local in-process server on Linux is supported)
+        # DPF core team thinks about to expose ANSYS_ROOT_FOLDER so that the absolute path
+        # can be easily constructed here.
+        # Different versions have different awp roots. Here we just try to load the plugins
+        # from different roots.
+        possible_awp_roots = [
+            "/ansys_inc/ansys/dpf/server_2023_2_pre1",
+            "/ansys_inc/ansys/dpf/server_2023_2_pre2",
+            "/ansys_inc/ansys/dpf/server_2024_1_pre0",
+        ]
 
-    while True:
-        awp_root_docker = possible_awp_roots.pop()
-        try:
-            _load_plugins(server, ansys_path=ansys_path, awp_root_docker=awp_root_docker)
-            return
-        except DPFServerException:
-            if len(possible_awp_roots) == 0:
-                raise
+        while True:
+            awp_root_docker = possible_awp_roots.pop()
+            try:
+                _load_plugins(server, ansys_path=ansys_path, awp_root_docker=awp_root_docker)
+                return
+            except DPFServerException:
+                if len(possible_awp_roots) == 0:
+                    raise
+    else:
+        for name in _PLUGINS:
+            # Since version 7.0, the dpf load_library method can load the plugins
+            # by passing their name (as defined in the _PLUGIN variable) in place
+            # of the filename.
+            # Note greschd July '23: AFAICT, The 'name' argument needs to be unique
+            # for each plugin. Otherwise, the plugin may not be loaded if another
+            # plugin with the same name is already loaded.
+            dpf.load_library(name, name=name, server=server)


### PR DESCRIPTION
When the DPF server version is `"7.0"` or higher, the
plugins can be loaded by passing their name instead
of the absolute path to the `filename` argument.

- Use the simplified plugin loading when the server
  version supports it.
- Remove `"/ansys_inc/ansys/dpf/server_2024_1_pre0"`
  from `possible_awp_roots`.