### PR TITLE
Remove 'library-namespace' argument from 'build-wheelhouse' action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -224,7 +224,6 @@ jobs:
         uses: ansys/actions/build-wheelhouse@v4
         with:
           library-name: "ansys-dpf-composites"
-          library-namespace: "ansys.dpf.composites"
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
The 'library-namespace' argument is no longer needed since version 4.1 of the 'build-wheelhouse' action.

See https://github.com/ansys/actions/blob/a590734dfa35ebb795738781585612cbe5a36c11/build-wheelhouse/action.yml#L12