### PR TITLE
CompositeFiles: convert rst always into a list.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,11 +33,12 @@ PyDPF Composites
    :alt: Black
 
 
-PyDPF Composites is a Python wrapper for Ansys DPF composites. It implements
-classes on top of DPF Composites operators and data accessors for short
-fiber and layered composites (layered shell and solid elements). This module
-can be used to postprocess fiber reinforced plastics and layered composites and
-to implement custom failure criteria and computation. For information demonstrating
+PyDPF Composites enables the post-processing of composite structures based on
+`Ansys DPF`_ and the DPF Composites plugin. It implements classes on top of
+DPF Composites operators and data accessors for short fiber and layered
+composites (layered shell and solid elements). This module can be used to
+postprocess fiber reinforced plastics and layered composites, and to implement
+custom failure criteria and computation. For information demonstrating
 the behavior and usage of PyDPF Composites, see `Examples`_ in the DPF Composite
 documentation.
 
@@ -196,3 +197,4 @@ released versions.
 .. _tox: https://tox.wiki/
 .. _Examples: https://composites.dpf.docs.pyansys.com/dev/examples/index.html
 .. _Getting The DPF Server Docker Image: https://composites.dpf.docs.pyansys.com/version/stable/intro.html#getting-the-dpf-server-docker-image
+.. _Ansys DPF: https://dpf.docs.pyansys.com/version/stable/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "ansys-dpf-composites"
 version = "0.3.dev0"
-description = "A python wrapper for ansys dpf composites"
+description = "Post-processing of composite structures based on Ansys DPF"
 license = "MIT"
 authors = ["ANSYS, Inc. <ansys.support@ansys.com>"]
 maintainers = ["PyAnsys developers <pyansys.maintainers@ansys.com>"]

--- a/src/ansys/dpf/composites/data_sources.py
+++ b/src/ansys/dpf/composites/data_sources.py
@@ -75,7 +75,7 @@ class ContinuousFiberCompositesFiles:
             True if files are on the local machine, False if they have already
             been uploaded to the DPF server..
         """
-        self.rst = rst
+        self.rst = rst  # type: ignore
         self.composite = composite
         self.engineering_data = engineering_data
         self.files_are_local = files_are_local
@@ -128,7 +128,7 @@ class ShortFiberCompositesFiles:
             True if files are on the local machine, False if they have already
             been uploaded to the DPF server..
         """
-        self.rst = rst
+        self.rst = rst  # type: ignore
         self.dsdat = dsdat
         self.engineering_data = engineering_data
         self.files_are_local = files_are_local

--- a/src/ansys/dpf/composites/data_sources.py
+++ b/src/ansys/dpf/composites/data_sources.py
@@ -75,12 +75,23 @@ class ContinuousFiberCompositesFiles:
             True if files are on the local machine, False if they have already
             been uploaded to the DPF server..
         """
-        if isinstance(rst, (str, pathlib.Path)):
-            rst = [rst]
-        self.rst = rst  # type: ignore
+        self.rst = self._get_rst_list(rst)
         self.composite = composite
         self.engineering_data = engineering_data
         self.files_are_local = files_are_local
+
+    # The constructor pretends that rst can also be just a path
+    # but the property rst must be a list
+    def __setattr__(self, prop, val):
+        if prop == "rst":
+            val = self._get_rst_list(val)
+        super().__setattr__(prop, val)
+
+    @staticmethod
+    def _get_rst_list(value: Union[List[_PATH], _PATH]) -> List[_PATH]:
+        if isinstance(value, (str, pathlib.Path)):
+            value = [value]
+        return value
 
 
 @dataclass
@@ -116,12 +127,23 @@ class ShortFiberCompositesFiles:
             True if files are on the local machine, False if they have already
             been uploaded to the DPF server..
         """
-        if isinstance(rst, (str, pathlib.Path)):
-            rst = [rst]
-        self.rst = rst  # type: ignore
+        self.rst = self._get_rst_list(rst)
         self.dsdat = dsdat
         self.engineering_data = engineering_data
         self.files_are_local = files_are_local
+
+    # The constructor pretends that rst can also be just a path
+    # but the property rst must be a list
+    def __setattr__(self, prop, val):
+        if prop == "rst":
+            val = self._get_rst_list(val)
+        super().__setattr__(prop, val)
+
+    @staticmethod
+    def _get_rst_list(value: Union[List[_PATH], _PATH]) -> List[_PATH]:
+        if isinstance(value, (str, pathlib.Path)):
+            value = [value]
+        return value
 
 
 # roosre June 2023: todo add deprecation warning where composite definition label is used

--- a/src/ansys/dpf/composites/data_sources.py
+++ b/src/ansys/dpf/composites/data_sources.py
@@ -92,7 +92,7 @@ class ContinuousFiberCompositesFiles:
     def _get_rst_list(value: Union[List[_PATH], _PATH]) -> List[_PATH]:
         if isinstance(value, (str, pathlib.Path)):
             value = [value]
-        return value
+        return value  # type: ignore
 
 
 @dataclass
@@ -145,7 +145,7 @@ class ShortFiberCompositesFiles:
     def _get_rst_list(value: Union[List[_PATH], _PATH]) -> List[_PATH]:
         if isinstance(value, (str, pathlib.Path)):
             value = [value]
-        return value
+        return value  # type: ignore
 
 
 # roosre June 2023: todo add deprecation warning where composite definition label is used

--- a/src/ansys/dpf/composites/data_sources.py
+++ b/src/ansys/dpf/composites/data_sources.py
@@ -75,7 +75,7 @@ class ContinuousFiberCompositesFiles:
             True if files are on the local machine, False if they have already
             been uploaded to the DPF server..
         """
-        self.rst = self._get_rst_list(rst)
+        self.rst = rst
         self.composite = composite
         self.engineering_data = engineering_data
         self.files_are_local = files_are_local
@@ -128,7 +128,7 @@ class ShortFiberCompositesFiles:
             True if files are on the local machine, False if they have already
             been uploaded to the DPF server..
         """
-        self.rst = self._get_rst_list(rst)
+        self.rst = rst
         self.dsdat = dsdat
         self.engineering_data = engineering_data
         self.files_are_local = files_are_local

--- a/src/ansys/dpf/composites/data_sources.py
+++ b/src/ansys/dpf/composites/data_sources.py
@@ -82,7 +82,8 @@ class ContinuousFiberCompositesFiles:
 
     # The constructor pretends that rst can also be just a path
     # but the property rst must be a list
-    def __setattr__(self, prop, val):
+    def __setattr__(self, prop, val):  # type: ignore
+        """Convert values if needed."""
         if prop == "rst":
             val = self._get_rst_list(val)
         super().__setattr__(prop, val)
@@ -134,7 +135,8 @@ class ShortFiberCompositesFiles:
 
     # The constructor pretends that rst can also be just a path
     # but the property rst must be a list
-    def __setattr__(self, prop, val):
+    def __setattr__(self, prop, val):  # type: ignore
+        """Convert values if needed."""
         if prop == "rst":
             val = self._get_rst_list(val)
         super().__setattr__(prop, val)

--- a/src/ansys/dpf/composites/data_sources.py
+++ b/src/ansys/dpf/composites/data_sources.py
@@ -134,7 +134,7 @@ class ShortFiberCompositesFiles:
         self.files_are_local = files_are_local
 
     # The constructor pretends that rst can also be just a path
-    # but the property rst must be a list
+    # but the property rst must be a list.
     def __setattr__(self, prop, val):  # type: ignore
         """Convert values if needed."""
         if prop == "rst":

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -57,3 +57,7 @@ def test_get_files_from_result_folder_harmonic(dpf_server):
 
     assert files.rst == [WORKFLOW_EXAMPLE_ROOT_HARMONIC / "file.rst"]
     assert files.engineering_data == WORKFLOW_EXAMPLE_ROOT_HARMONIC / "MatML.xml"
+
+    # ensure that the setter of RST converts the input into a list
+    files.rst = WORKFLOW_EXAMPLE_ROOT_HARMONIC / "file.rst"
+    assert files.rst == [WORKFLOW_EXAMPLE_ROOT_HARMONIC / "file.rst"]


### PR DESCRIPTION
Closes #346 

You have to manually set the `rst` path if ansys-dpf-composites is used in combination with for example a transient analysis. The constructor of CompositeFiles pretends that the member `rst` can be a Path or list of paths but finally it must be a list of paths. That is now enforced when the user manually sets a value for `rst`.