### PR TITLE
Sort composite definition labels before comparing in test. 

### DIFF
--- a/tests/composite_model_scoping_test.py
+++ b/tests/composite_model_scoping_test.py
@@ -58,8 +58,8 @@ def test_composite_model_named_selection_scope(dpf_server, data_files, distribut
     failure_container = composite_model.evaluate_failure_criteria(cfc, scope)
     irfs = failure_container.get_field({"failure_label": FailureOutput.FAILURE_VALUE})
     assert len(irfs.data) == 2
-    assert irfs.data[0] == pytest.approx(1.4792790331384016, 1e-8)
-    assert irfs.data[1] == pytest.approx(1.3673715033617213, 1e-8)
+    assert irfs.get_entity_data_by_id(2) == pytest.approx(1.4792790331384016, 1e-8)
+    assert irfs.get_entity_data_by_id(3) == pytest.approx(1.3673715033617213, 1e-8)
 
 
 def test_composite_model_ply_scope(dpf_server):
@@ -102,21 +102,50 @@ def test_composite_model_ply_scope(dpf_server):
     if version_older_than(dpf_server, "7.0"):
         # the old implementation did not allow to distinguish between plies of the different parts.
         # So both plies select the shell and solid elements.
+        expected_irfs_by_element_id = {
+            1: 0.66603946,
+            2: 0.66603946,
+            7: 3.24925826,
+            8: 3.24925826,
+            9: 0.52981576,
+            10: 0.52981576,
+        }
+
+        expected_modes_by_element_id = {1: 310.0, 2: 310.0, 7: 310.0, 8: 310.0, 9: 212.0, 10: 222.0}
         assert len(irfs.data) == 6
-        assert irfs.data == pytest.approx(
-            np.array([0.66603946, 0.66603946, 3.24925826, 0.52981576, 3.24925826, 0.52981576]),
-            abs=1e-3,
-        )
-        assert modes.data == pytest.approx(
-            np.array([310.0, 310.0, 310.0, 222.0, 310.0, 212.0]), abs=0.1
-        )
+        for element_id in irfs.scoping.ids:
+            assert expected_irfs_by_element_id[element_id] == pytest.approx(
+                irfs.get_entity_data_by_id(element_id), abs=1e-3
+            )
+            assert expected_modes_by_element_id[element_id] == pytest.approx(
+                modes.get_entity_data_by_id(element_id), abs=0.1
+            )
+
     else:
         # ply scoping is now part specific thanks to the labels
         assert len(irfs.data) == 4
-        assert irfs.data == pytest.approx(
-            np.array([0.14762838, 0.14762838, 3.24925826, 3.24925826]), abs=1e-3
-        )
-        assert modes.data == pytest.approx(np.array([222, 212, 310, 310]), abs=0.1)
+
+        expected_irfs_by_element_id = {
+            1: 0.14762838,
+            2: 0.14762838,
+            7: 3.24925826,
+            8: 3.24925826,
+        }
+
+        expected_modes_by_element_id = {
+            1: 222,
+            2: 212,
+            7: 310,
+            8: 310,
+        }
+
+        for element_id in irfs.scoping.ids:
+            assert irfs.get_entity_data_by_id(element_id) == pytest.approx(
+                expected_irfs_by_element_id[element_id], abs=1e-3
+            )
+            assert modes.get_entity_data_by_id(element_id) == pytest.approx(
+                expected_modes_by_element_id[element_id], abs=1e-1
+            )
 
 
 def test_composite_model_named_selection_and_ply_scope(dpf_server, data_files, distributed_rst):
@@ -147,8 +176,15 @@ def test_composite_model_named_selection_and_ply_scope(dpf_server, data_files, d
     modes = failure_container.get_field({"failure_label": FailureOutput.FAILURE_MODE})
     assert len(irfs.data) == 2
     assert len(modes.data) == 2
-    assert irfs.data == pytest.approx(np.array([0.49282684, 0.32568454]), abs=1e-3)
-    assert modes.data == pytest.approx(np.array([222.0, 222.0]), abs=1e-1)
+    expected_irfs_by_id = {2: 0.49282684, 3: 0.32568454}
+    expected_modes_by_id = {2: 222.0, 3: 222.0}
+    for element_id in irfs.scoping.ids:
+        assert irfs.get_entity_data_by_id(element_id) == pytest.approx(
+            expected_irfs_by_id[element_id], abs=1e-3
+        )
+        assert modes.get_entity_data_by_id(element_id) == pytest.approx(
+            expected_modes_by_id[element_id], abs=1e-1
+        )
 
 
 def test_composite_model_time_scope(dpf_server):
@@ -173,6 +209,5 @@ def test_composite_model_time_scope(dpf_server):
         scope = CompositeScope(time=time)
         failure_container = composite_model.evaluate_failure_criteria(cfc, scope)
         irfs = failure_container.get_field({"failure_label": FailureOutput.FAILURE_VALUE})
-        modes = failure_container.get_field({"failure_label": FailureOutput.FAILURE_MODE})
         assert len(irfs.data) == 4
         assert max(irfs.data) == pytest.approx(expected_max_irf, abs=1e-6)

--- a/tests/composite_model_test.py
+++ b/tests/composite_model_test.py
@@ -115,7 +115,7 @@ def test_assembly_model(dpf_server):
     composite_model = CompositeModel(files, server=dpf_server)
     timer.add("After Setup model")
 
-    assert composite_model.composite_definition_labels == [solid_label, shell_label]
+    assert sorted(composite_model.composite_definition_labels) == sorted([solid_label, shell_label])
 
     combined_failure_criterion = CombinedFailureCriterion(
         "max strain & max stress", failure_criteria=[MaxStressCriterion()]

--- a/tests/performance_test.py
+++ b/tests/performance_test.py
@@ -287,45 +287,6 @@ def test_performance_property_dict(dpf_server):
     timer.summary()
 
 
-def test_merge(dpf_server):
-    merger = dpf.operators.utility.merge_fields_containers(server=dpf_server)
-
-    def get_container_1():
-        field_element_nodal = dpf.Field(location=dpf.locations.elemental_nodal, server=dpf_server)
-
-        data = [1, 2, 3, 4]
-        field_element_nodal.append(data, 1)
-        field_element_nodal.append(data, 2)
-
-        container = dpf.FieldsContainer()
-        container.add_label("test")
-        container.add_field({"test": 0}, field_element_nodal)
-
-        return container
-
-    def get_container_2():
-        field_element_nodal = dpf.Field(location=dpf.locations.elemental_nodal, server=dpf_server)
-
-        data = [1, 2, 3]
-        field_element_nodal.append(data, 3)
-        field_element_nodal.append(data, 4)
-        field_element_nodal.append(data, 5)
-
-        container = dpf.FieldsContainer()
-        container.add_label("test")
-        container.add_field({"test": 0}, field_element_nodal)
-
-        return container
-
-    merger.inputs.fields_containers1.connect(get_container_1())
-    merger.inputs.fields_containers2.connect(get_container_2())
-
-    merged_containers = merger.outputs.merged_fields_container()
-
-    element_nodal_field = merged_containers.get_field({"test": 0})
-    assert element_nodal_field.data.size == 17
-
-
 def test_performance_flat(dpf_server):
     """
     This test shows how composite data can be stored

--- a/tests/performance_test.py
+++ b/tests/performance_test.py
@@ -287,6 +287,45 @@ def test_performance_property_dict(dpf_server):
     timer.summary()
 
 
+def test_merge(dpf_server):
+    merger = dpf.operators.utility.merge_fields_containers(server=dpf_server)
+
+    def get_container_1():
+        field_element_nodal = dpf.Field(location=dpf.locations.elemental_nodal, server=dpf_server)
+
+        data = [1, 2, 3, 4]
+        field_element_nodal.append(data, 1)
+        field_element_nodal.append(data, 2)
+
+        container = dpf.FieldsContainer()
+        container.add_label("test")
+        container.add_field({"test": 0}, field_element_nodal)
+
+        return container
+
+    def get_container_2():
+        field_element_nodal = dpf.Field(location=dpf.locations.elemental_nodal, server=dpf_server)
+
+        data = [1, 2, 3]
+        field_element_nodal.append(data, 3)
+        field_element_nodal.append(data, 4)
+        field_element_nodal.append(data, 5)
+
+        container = dpf.FieldsContainer()
+        container.add_label("test")
+        container.add_field({"test": 0}, field_element_nodal)
+
+        return container
+
+    merger.inputs.fields_containers1.connect(get_container_1())
+    merger.inputs.fields_containers2.connect(get_container_2())
+
+    merged_containers = merger.outputs.merged_fields_container()
+
+    element_nodal_field = merged_containers.get_field({"test": 0})
+    assert element_nodal_field.data.size == 17
+
+
 def test_performance_flat(dpf_server):
     """
     This test shows how composite data can be stored


### PR DESCRIPTION
Their order is irrelevant since all lookups happen with the label.