### PR TITLE
Update minimum DPF core requirement to 0.8.0

### DIFF
--- a/.ci/minimum_requirements.txt
+++ b/.ci/minimum_requirements.txt
@@ -1,5 +1,5 @@
 # Contains minimum requirements that we support
 numpy == 1.22.0
 matplotlib == 3.5.0
-ansys-dpf-core == 0.7.3
+ansys-dpf-core == 0.8.0
 pyvista == 0.36.1


### PR DESCRIPTION
Update the minimum requirement for `ansys-dpf-core` to `0.8.0` in
`minimum_requirements.txt`, to match the `pyproject.toml` definition
`>=0.8,<1`.