### PR TITLE
cicd: update add-license-header hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     exclude: '^poetry\.lock$'
 
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.2.6
+  rev: v0.2.8
   hooks:
   - id: add-license-headers
     args: ["--start_year", "2023"]


### PR DESCRIPTION
Closes https://github.com/ansys/pre-commit-hooks/issues/129

The main issue is that version 0.2.6 did not set an upper limit on `reuse`. By updating the version, the previous issue mentioned should not occur.