### PR TITLE
Fix vale warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ server is started.
 
 #.  Run tests with a Docker container:
 
-    Follow the steps in `Getting The DPF Server Docker Image`_ to get
+    Follow the steps in `Getting the DPF server Docker image`_ to get
     and run the DPF docker image. Run the tests with the following command
 
     .. code:: bash
@@ -130,7 +130,7 @@ server is started.
 Build documentation
 ===================
 
-Follow the description in `Getting The DPF Server Docker Image`_ image to get
+Follow the description in `Getting the DPF server Docker image`_ image to get
 and run the dpf docker image.
 
 On Windows, build the documentation with:
@@ -196,5 +196,5 @@ released versions.
 .. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _tox: https://tox.wiki/
 .. _Examples: https://composites.dpf.docs.pyansys.com/version/stable/examples/index.html
-.. _Getting The DPF Server Docker Image: https://composites.dpf.docs.pyansys.com/version/stable/intro.html#getting-the-dpf-server-docker-image
+.. _Getting the DPF server Docker image: https://composites.dpf.docs.pyansys.com/version/stable/intro.html#getting-the-dpf-server-docker-image
 .. _Ansys DPF: https://dpf.docs.pyansys.com/version/stable/

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -128,8 +128,8 @@ By default the DPF server is started from the latest Ansys installer. To choose 
 
 .. _Get DPF Docker image:
 
-Getting the DPF Server Docker Image
+Getting the DPF server Docker image
 """""""""""""""""""""""""""""""""""
 Follow the steps described in the DPF documentation in the section `Run DPF Server in A Docker Container <https://dpf.docs.pyansys.com/version/stable/user_guide/getting_started_with_dpf_server.html#run-dpf-server-in-a-docker-container>`_.
 Make sure you also download the composites plugin (e.g ``ansys_dpf_composites_lin_v2024.1.pre0.zip``).
-After following the steps above, you should have a running DPF docker container that listens to port 50052.
+After following the preceding steps, you should have a running DPF Docker container that listens to port 50052.

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -8,4 +8,7 @@ postprocess
 Postprocessing
 postprocessing
 ply-wise
-
+API
+Docker
+DPF
+dpf


### PR DESCRIPTION
Vale had a breaking change / bug where warnings now cause a non-zero
exit code. To get PR (e.g. dependabot) working again, we need to fix the
warnings.