### PR TITLE
Convert slices to list before appending to dpf field

### DIFF
--- a/examples/006_filter_composite_data_example.py
+++ b/examples/006_filter_composite_data_example.py
@@ -139,7 +139,7 @@ with result_field.as_local_field() as local_result_field:
         )
 
         value = stress_data[selected_indices][:, component]
-        # value needs to be passed as list because dpf does not support numpyy
+        # value needs to be passed as list because dpf does not support numpy
         # slices in the append call.
         local_result_field.append(list(value), element_id)
 

--- a/examples/006_filter_composite_data_example.py
+++ b/examples/006_filter_composite_data_example.py
@@ -141,7 +141,7 @@ with result_field.as_local_field() as local_result_field:
         value = stress_data[selected_indices][:, component]
         # value needs to be passed as list because dpf does not support numpy
         # slices in the append call.
-        local_result_field.append(list(value), element_id)
+        local_result_field.append(value.tolist(), element_id)
 
 composite_model.get_mesh().plot(result_field)
 

--- a/examples/006_filter_composite_data_example.py
+++ b/examples/006_filter_composite_data_example.py
@@ -139,7 +139,9 @@ with result_field.as_local_field() as local_result_field:
         )
 
         value = stress_data[selected_indices][:, component]
-        local_result_field.append(value, element_id)
+        # value needs to be passed as list because dpf does not support numpyy
+        # slices in the append call.
+        local_result_field.append(list(value), element_id)
 
 composite_model.get_mesh().plot(result_field)
 

--- a/tests/filter_layered_data_test.py
+++ b/tests/filter_layered_data_test.py
@@ -166,7 +166,7 @@ def test_filter_by_global_ply(dpf_server):
                 component = 0
                 value = strain_data[selected_indices][:, component]
 
-                local_result_field.append(value, element_id)
+                local_result_field.append(list(value), element_id)
 
     # Ply is only present in element 1 and 2
     assert list(result_field.scoping.ids) == [1, 2]

--- a/tests/filter_layered_data_test.py
+++ b/tests/filter_layered_data_test.py
@@ -81,7 +81,7 @@ def get_result_field(
                     # Conversion to a list is a temporary workaround
                     # because the append method does currently not work
                     # reliably for slices of numpy arrays
-                    local_result_field.append(list(values), element_id)
+                    local_result_field.append(values.tolist(), element_id)
                 else:
                     local_result_field.append(strain_data[selected_indices, component], element_id)
     return result_field
@@ -166,7 +166,7 @@ def test_filter_by_global_ply(dpf_server):
                 component = 0
                 value = strain_data[selected_indices][:, component]
 
-                local_result_field.append(list(value), element_id)
+                local_result_field.append(value.tolist(), element_id)
 
     # Ply is only present in element 1 and 2
     assert list(result_field.scoping.ids) == [1, 2]


### PR DESCRIPTION
Since slices are not supported for append. Discovered when testing the new prerelase for the dpf server.