### PR TITLE
Fix output for non-irf failure

### DIFF
--- a/src/ansys/dpf/composites/_composite_model_impl.py
+++ b/src/ansys/dpf/composites/_composite_model_impl.py
@@ -521,21 +521,12 @@ class CompositeModelImpl:
                 max_merger.outputs.merged_fields_container()
             )
 
-            if measure == FailureMeasureEnum.INVERSE_RESERVE_FACTOR:
-                return _merge_containers(
-                    max_merger.outputs.merged_fields_container(),
-                    self._map_to_reference_surface_operator.outputs.max_container(),
-                )
-            else:
-                return _merge_containers(
-                    min_merger.outputs.merged_fields_container(),
-                    self._map_to_reference_surface_operator.outputs.min_container(),
-                )
+            return _merge_containers(
+                max_merger.outputs.merged_fields_container(),
+                self._map_to_reference_surface_operator.outputs.max_container(),
+            )
         else:
-            if measure == FailureMeasureEnum.INVERSE_RESERVE_FACTOR:
-                return max_merger.outputs.merged_fields_container()
-            else:
-                return min_merger.outputs.merged_fields_container()
+            return max_merger.outputs.merged_fields_container()
 
     @_deprecated_composite_definition_label
     def get_sampling_point(

--- a/src/ansys/dpf/composites/_composite_model_impl.py
+++ b/src/ansys/dpf/composites/_composite_model_impl.py
@@ -526,7 +526,7 @@ class CompositeModelImpl:
             converter_op.run()
 
             if version_older_than(self._server, "8.2"):
-                # For versions before 8.1, the Reference Surface suffix
+                # For versions before 8.2, the Reference Surface suffix
                 # is not correctly preserved by the failure_measure_converter
                 # We add the suffix manually here.
                 for field in ref_surface_max_container:
@@ -536,7 +536,10 @@ class CompositeModelImpl:
                         or field.name.startswith("SM")
                     ):
                         assert not field.name.endswith(REF_SURFACE_NAME)
-                        field.name = field.name + " " + REF_SURFACE_NAME
+                        # Set name in field definition, because setting
+                        # the name directly is not supported for older dpf versions
+                        field_definition = field.field_definition
+                        field_definition.name = field_definition.name + " " + REF_SURFACE_NAME
 
             return _merge_containers(overall_max_container, ref_surface_max_container)
         else:

--- a/src/ansys/dpf/composites/_composite_model_impl.py
+++ b/src/ansys/dpf/composites/_composite_model_impl.py
@@ -525,14 +525,11 @@ class CompositeModelImpl:
             converter_op.inputs.fields_container(ref_surface_max_container)
             converter_op.run()
 
-            return _merge_containers(
-                max_merger.outputs.merged_fields_container(), ref_surface_max_container
-            )
+            return _merge_containers(overall_max_container, ref_surface_max_container)
         else:
-            overall_max_container = max_merger.outputs.merged_fields_container()
             converter_op = dpf.Operator("composite::failure_measure_converter")
             converter_op.inputs.measure_type(measure.value)
-            converter_op.inputs.fields_container(overall_max_container)
+            converter_op.inputs.fields_container(max_merger.outputs.merged_fields_container())
             converter_op.run()
             return max_container
 

--- a/src/ansys/dpf/composites/_composite_model_impl.py
+++ b/src/ansys/dpf/composites/_composite_model_impl.py
@@ -523,26 +523,20 @@ class CompositeModelImpl:
             converter_op.inputs.fields_container(overall_max_container)
             converter_op.run()
             converter_op.inputs.fields_container(ref_surface_max_container)
+            converter_op.run()
 
-            if version_older_than(self._server, "8.1"):
+            if version_older_than(self._server, "8.2"):
                 # For versions before 8.1, the Reference Surface suffix
                 # is not correctly preserved by the failure_measure_converter
                 # We add the suffix manually here.
-                reference_surface_suffix = " Reference Surface"
-
-                def add_ref_surface_suffix(field: dpf.Field) -> None:
-                    field.name = field.name + reference_surface_suffix
-
-                add_ref_surface_suffix(
-                    ref_surface_max_container.get_field(
-                        {FAILURE_LABEL: FailureOutput.FAILURE_MODE_REF_SURFACE}
-                    )
-                )
-                add_ref_surface_suffix(
-                    ref_surface_max_container.get_field(
-                        {FAILURE_LABEL: FailureOutput.FAILURE_VALUE_REF_SURFACE}
-                    )
-                )
+                for field in ref_surface_max_container:
+                    if (
+                        field.name.startswith("IRF")
+                        or field.name.startswith("SF")
+                        or field.name.startswith("SM")
+                    ):
+                        assert not field.name.endswith(REF_SURFACE_NAME)
+                        field.name = field.name + " " + REF_SURFACE_NAME
 
             return _merge_containers(overall_max_container, ref_surface_max_container)
         else:

--- a/src/ansys/dpf/composites/_composite_model_impl_2023r2.py
+++ b/src/ansys/dpf/composites/_composite_model_impl_2023r2.py
@@ -336,10 +336,7 @@ class CompositeModelImpl2023R2:
 
         failure_operator.inputs.result_definition(rd.to_json())
 
-        if measure == FailureMeasureEnum.INVERSE_RESERVE_FACTOR:
-            return failure_operator.outputs.fields_containerMax()
-        else:
-            return failure_operator.outputs.fields_containerMin()
+        return failure_operator.outputs.fields_containerMax()
 
     def get_sampling_point(
         self,

--- a/src/ansys/dpf/composites/server_helpers/_versions.py
+++ b/src/ansys/dpf/composites/server_helpers/_versions.py
@@ -45,9 +45,9 @@ _DPF_VERSIONS: dict[str, _DpfVersionInfo] = {
         "DPF Composites: reference surface support and \
                                                    section data from RST",
     ),
-    "8.1": _DpfVersionInfo(
-        "8.1",
-        "2024 R2 pre 1",
+    "8.2": _DpfVersionInfo(
+        "8.2",
+        "2024 R2 pre 2",
         "DPF Composites: Failure measure conversion preserves Reference Surface suffix",
     ),
 }

--- a/src/ansys/dpf/composites/server_helpers/_versions.py
+++ b/src/ansys/dpf/composites/server_helpers/_versions.py
@@ -45,6 +45,11 @@ _DPF_VERSIONS: dict[str, _DpfVersionInfo] = {
         "DPF Composites: reference surface support and \
                                                    section data from RST",
     ),
+    "8.1": _DpfVersionInfo(
+        "8.1",
+        "2024 R2 pre 1",
+        "DPF Composites: Failure measure conversion preserves Reference Surface suffix",
+    ),
 }
 
 

--- a/tests/composite_model_test.py
+++ b/tests/composite_model_test.py
@@ -237,7 +237,7 @@ def test_assembly_model(dpf_server, failure_measure):
             failure_field = failure_output.get_field({FAILURE_LABEL: failure_label})
             assert failure_field.get_entity_data_by_id(element_id) == pytest.approx(expected_value)
 
-    def check_mode_output(failure_label: FailureOutput, expected_output: dict[int, float]):
+    def check_mode_or_layer_output(failure_label: FailureOutput, expected_output: dict[int, float]):
         for element_id, expected_value in expected_output.items():
             failure_field = failure_output.get_field({FAILURE_LABEL: failure_label})
             assert failure_field.get_entity_data_by_id(element_id) == pytest.approx(expected_value)
@@ -264,7 +264,7 @@ def test_assembly_model(dpf_server, failure_measure):
         9: FailureModeEnum.s2t.value,
         10: FailureModeEnum.s2t.value,
     }
-    check_mode_output(FailureOutput.FAILURE_MODE, expected_modes)
+    check_mode_or_layer_output(FailureOutput.FAILURE_MODE, expected_modes)
 
     expected_layer_index = {
         1: 2,
@@ -283,7 +283,7 @@ def test_assembly_model(dpf_server, failure_measure):
             # at 0 instead of 1
             expected_layer_index[element_id] -= 1
 
-    check_mode_output(FailureOutput.MAX_LAYER_INDEX, expected_layer_index)
+    check_mode_or_layer_output(FailureOutput.MAX_LAYER_INDEX, expected_layer_index)
 
     expected_output_irf_ref_surface = {
         1: 1.85777034,
@@ -301,7 +301,9 @@ def test_assembly_model(dpf_server, failure_measure):
             3: 2,
             4: 2,
         }
-        check_mode_output(FailureOutput.MAX_LOCAL_LAYER_IN_ELEMENT, expected_output_local_layer)
+        check_mode_or_layer_output(
+            FailureOutput.MAX_LOCAL_LAYER_IN_ELEMENT, expected_output_local_layer
+        )
 
         expected_output_global_layer = {
             1: 2,
@@ -309,7 +311,9 @@ def test_assembly_model(dpf_server, failure_measure):
             3: 2,
             4: 2,
         }
-        check_mode_output(FailureOutput.MAX_GLOBAL_LAYER_IN_STACK, expected_output_global_layer)
+        check_mode_or_layer_output(
+            FailureOutput.MAX_GLOBAL_LAYER_IN_STACK, expected_output_global_layer
+        )
 
         expected_output_solid_element = {
             1: 5,
@@ -317,7 +321,9 @@ def test_assembly_model(dpf_server, failure_measure):
             3: 1,
             4: 2,
         }
-        check_mode_output(FailureOutput.MAX_SOLID_ELEMENT_ID, expected_output_solid_element)
+        check_mode_or_layer_output(
+            FailureOutput.MAX_SOLID_ELEMENT_ID, expected_output_solid_element
+        )
 
     property_dict = composite_model.get_constant_property_dict(
         [MaterialProperty.Stress_Limits_Xt], composite_definition_label=solid_label

--- a/tests/filter_layered_data_test.py
+++ b/tests/filter_layered_data_test.py
@@ -166,7 +166,7 @@ def test_filter_by_global_ply(dpf_server):
                 component = 0
                 value = strain_data[selected_indices][:, component]
 
-                local_result_field.append(value, element_id)
+                local_result_field.append(value.tolist(), element_id)
 
     # Ply is only present in element 1 and 2
     assert list(result_field.scoping.ids) == [1, 2]


### PR DESCRIPTION
Always use the "max" container since it contains the worst failure value. Also see the corresponding backend PR. Some tests currently fail because the the "convert_failure_measure" operator does not correctly preserve the "Reference Surface" suffix in the field name. This will be fixed once the backend PR is merged.