### PR TITLE
Improve the handling of missing materials

### DIFF
--- a/src/ansys/dpf/composites/layup_info/material_operators.py
+++ b/src/ansys/dpf/composites/layup_info/material_operators.py
@@ -145,12 +145,15 @@ def get_material_operators(
     # Combines the material support in the engineering data XML file and the unit system.
     # Its output can be used to evaluate material properties.
     material_provider = Operator("eng_data::ans_mat_material_provider")
-    material_provider.inputs.data_sources = engineering_data_source
     material_provider.inputs.unit_system_or_result_info(unit_system)
     material_provider.inputs.abstract_field_support(
         material_support_provider.outputs.abstract_field_support
     )
     material_provider.inputs.Engineering_data_file(engineering_data_source)
+    #BUG 1060154: Mechanical adds materials to the MAPDL model for flexible
+    # Remote Points etc. These materials should be skipped by adding
+    # materials without properties.
+    material_provider.inputs.skip_missing_materials(True)
 
     return MaterialOperators(
         material_provider=material_provider,

--- a/src/ansys/dpf/composites/layup_info/material_operators.py
+++ b/src/ansys/dpf/composites/layup_info/material_operators.py
@@ -151,6 +151,7 @@ def get_material_operators(
     )
     material_provider.inputs.Engineering_data_file(engineering_data_source)
 
+    # pylint: disable=protected-access
     if version_equal_or_later(rst_data_source._server, "9.0"):
         # BUG 1060154: Mechanical adds materials to the MAPDL model for flexible
         # Remote Points etc. These materials should be skipped by adding

--- a/src/ansys/dpf/composites/layup_info/material_operators.py
+++ b/src/ansys/dpf/composites/layup_info/material_operators.py
@@ -150,10 +150,12 @@ def get_material_operators(
         material_support_provider.outputs.abstract_field_support
     )
     material_provider.inputs.Engineering_data_file(engineering_data_source)
-    #BUG 1060154: Mechanical adds materials to the MAPDL model for flexible
-    # Remote Points etc. These materials should be skipped by adding
-    # materials without properties.
-    material_provider.inputs.skip_missing_materials(True)
+
+    if version_equal_or_later(rst_data_source._server, "9.0"):
+        # BUG 1060154: Mechanical adds materials to the MAPDL model for flexible
+        # Remote Points etc. These materials should be skipped by adding
+        # materials without properties.
+        material_provider.inputs.skip_missing_materials(True)
 
     return MaterialOperators(
         material_provider=material_provider,


### PR DESCRIPTION
ADO BUG 1060154
It could happen that Mechanical adds materials to the MAPDL model. For instance for flexible remote points. These materials are not present in the ENGD file. Instead of throwing an error, empty materials are added to the material provider if the new input pint "skip_missing_materials" is equals True. The failure operator will throw an error because of missing properties  if such a material is used during the computation.