### PR TITLE
Install pip<24.1 for minimum requirements test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,11 +47,15 @@ allowlist_externals  =
     poetry
 setenv =
     PYTHONUNBUFFERED = yes
-; uninstalling ansys-dpf-core explicitly is needed because downgrading to 0.8.0
+; Uninstalling ansys-dpf-core explicitly is needed because downgrading to 0.8.0
 ; directly fails, see https://github.com/ansys/pydpf-core/issues/1306
+; Also, 'ansys-dpf-core' 0.8.0 needs a pip version lower than 24.1, since its
+; dependency on 'ansys-dpf-gate>=0.3.*' is marked as invalid and rejected by pip
+; versions 24.1 and above.
 commands =
     poetry install -E test
     poetry run python -m pip uninstall -y ansys-dpf-core
+    poetry run python -m pip install 'pip<24.1'
     poetry run python -m pip install -r .ci/minimum_requirements.txt
     poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} {env:PYTEST_MARKERS:} {posargs:-vv}
 


### PR DESCRIPTION
The `ansys-dpf-core` version `0.8.0` cannot be installed with `pip` version `24.1` and above, since
its dependency on `ansys-dpf-gate>=0.3.*` is identified as invalid metadata (the `*` only being allowed
with `==` and `!=` relations).

For the purposes of checking our backwards compatibility, we can simply use an older version of pip.