### PR TITLE
support of dpf server 9.0 (2025R1 pre0)

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -73,6 +73,7 @@ jobs:
         # if other containers must be tested.
         run:  |
           docker pull ghcr.io/ansys/pydpf-composites:${{ env.CONTAINER_TAG }}
+          docker pull ghcr.io/ansys/pydpf-composites:2025r1_pre0
           docker pull ghcr.io/ansys/pydpf-composites:2024r2_pre1
           docker pull ghcr.io/ansys/pydpf-composites:2024r2_pre0
           docker pull ghcr.io/ansys/pydpf-composites:2024r1_pre0

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -112,6 +112,8 @@ By default the DPF server is started from the latest Ansys installer. To choose 
 
    * - Server version
      - ansys.dpf.composites Python module version
+   * - 9.0 (Ansys 2025 R1 pre0)
+     - 0.3.0 and later
    * - 8.1 (Ansys 2024 R2 pre1)
      - 0.3.0 and later
    * - 8.0 (Ansys 2024 R2 pre0)

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ setenv =
 commands =
     poetry install -E test
     poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=latest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
+    poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2025r1_pre0 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
     poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2024r2_pre1 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
     poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2024r2_pre0 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
     poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2024r1 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}


### PR DESCRIPTION
Prepare the next release of ansys-dpf-composites which supports DPF 2025 R1 pre0 (server version 9.0)