### PR TITLE
Fix code style action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -32,7 +32,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          # TODO: switch back to using ${{ env.MAIN_PYTHON_VERSION }}
+          # once https://github.com/pylint-dev/pylint/issues/10000#issuecomment-2519899671
+          # is resolved.
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip tox

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ commands =
 description = Checks project code style
 skip_install = true
 basepython =
- python3.13
+ python3.12 # TODO: move to 3.13 once https://github.com/pylint-dev/pylint/issues/10000#issuecomment-2519899671 is fixed
 allowlist_externals  =
     poetry
 commands =


### PR DESCRIPTION
Code style checks fail with the new `3.13.1` release of Python, due to https://github.com/pylint-dev/pylint/issues/10000#issuecomment-2519899671.
Switching back to 3.12 for this action.