### PR TITLE
Rename from 'PyDPF Composites' to 'PyDPF - Composites'

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip tox
-          python -m pip install --upgrade poetry
+          python -m pip install --upgrade 'poetry<2'
 
       - name: Test with tox
         run: tox -e style
@@ -94,7 +94,7 @@ jobs:
       - name: "Install Python dependencies"
         run: |
           python -m pip install --upgrade pip tox tox-gh-actions
-          python -m pip install --upgrade poetry
+          python -m pip install --upgrade 'poetry<2'
 
       - name: "Test with tox"
         # Only the tox environment specified in the tox.ini gh-actions is run
@@ -141,7 +141,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip tox tox-gh-actions
-          python -m pip install --upgrade poetry
+          python -m pip install --upgrade 'poetry<2'
 
       - name: Test with tox
         run: |
@@ -181,7 +181,7 @@ jobs:
       - name: "Install Python dependencies"
         run: |
           python -m pip install --upgrade pip tox
-          python -m pip install --upgrade poetry
+          python -m pip install --upgrade 'poetry<2'
 
       - name: "Generate the documentation with tox"
         run: |

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+Copyright (c) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-****************
-PyDPF Composites
-****************
+******************
+PyDPF - Composites
+******************
 
 |pyansys| |python| |pypi| |GH-CI| |codecov| |MIT| |black|
 
@@ -33,13 +33,13 @@ PyDPF Composites
    :alt: Black
 
 
-PyDPF Composites enables the post-processing of composite structures based on
+PyDPF - Composites enables the post-processing of composite structures based on
 `Ansys DPF`_ and the DPF Composites plugin. So it is a Python wrapper which
 implements classes on top of DPF Composites operators and data accessors for
 short fiber and layered composites (layered shell and solid elements). This
 module can be used to postprocess fiber reinforced plastics and layered
 composites, and to implement custom failure criteria and computation. For
-information demonstrating the behavior and usage of PyDPF Composites,
+information demonstrating the behavior and usage of PyDPF - Composites,
 see `Examples`_ in the DPF Composite documentation.
 
 .. START_MARKER_FOR_SPHINX_DOCS
@@ -51,10 +51,10 @@ Contribute
 Install in development mode
 ===========================
 
-Installing PyDPF Composites in development mode allows
+Installing PyDPF - Composites in development mode allows
 you to modify the source and enhance it.
 
-Before attempting to contribute to PyDPF Composites, ensure that you are thoroughly
+Before attempting to contribute to PyDPF - Composites, ensure that you are thoroughly
 familiar with the `PyAnsys Developer's Guide`_.
 
 #.  Clone the repository:
@@ -77,7 +77,7 @@ familiar with the `PyAnsys Developer's Guide`_.
         pipx install tox
 
 
-    PyDPF Composites uses `Poetry <https://python-poetry.org>`_
+    PyDPF - Composites uses `Poetry <https://python-poetry.org>`_
     to manage the development environment.
 
 #.  Create a virtual environment and install the package with the
@@ -98,7 +98,7 @@ familiar with the `PyAnsys Developer's Guide`_.
 Test
 ====
 
-There are different ways to run the PyDPF Composites tests, depending on how the DPF
+There are different ways to run the PyDPF - Composites tests, depending on how the DPF
 server is started.
 
 #.  Run tests with a Docker container:
@@ -175,8 +175,8 @@ The style checks can also be configured to run automatically before each ``git c
 
 View documentation
 -------------------
-Documentation for the latest stable release of PyDPF Composites is hosted at
-`PyDPF Composites Documentation <https://composites.dpf.docs.pyansys.com/version/stable/>`_.
+Documentation for the latest stable release of PyDPF - Composites is hosted at
+`PyDPF - Composites Documentation <https://composites.dpf.docs.pyansys.com/version/stable/>`_.
 
 In the upper right corner of the documentation's title bar, there is an option
 for switching from viewing the documentation for the latest stable release

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -1,7 +1,7 @@
 API reference
 =============
 
-This section describes the public classes, methods, and attributes of the PyDPF Composites API.
+This section describes the public classes, methods, and attributes of the PyDPF - Composites API.
 
 For in-depth documentation on the different failure criteria, refer to the ACP help.
 

--- a/doc/source/api/layup_info.rst
+++ b/doc/source/api/layup_info.rst
@@ -25,7 +25,7 @@ General features to access information on the composite lay-up.
 
 Material properties
 '''''''''''''''''''
-A note on material ids: in the PyDPF Composites module,
+A note on material ids: in the PyDPF - Composites module,
 materials are reference by their ``dpf_material_id``. The ``dpf_material_id``
 is generated based on the materials present in the result file.
 The ``dpf_material_id`` can be different from the material id used in the solver.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,7 +30,7 @@ release = version = __version__
 # Select desired logo, theme, and declare the html title
 html_favicon = ansys_favicon
 html_theme = "ansys_sphinx_theme"
-html_short_title = html_title = "PyDPF Composites"
+html_short_title = html_title = "PyDPF - Composites"
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -8,10 +8,10 @@
    examples/index
    contribute
 
-PyDPF Composites
-----------------
+PyDPF - Composites
+------------------
 
-PyDPF Composites enables the post-processing of composite structures based on
+PyDPF - Composites enables the post-processing of composite structures based on
 `Ansys DPF`_ and the DPF Composites plugin. It implements
 classes on top of DPF Composites operators and data accessors for short
 fiber and layered composites (layered shell and solid elements). This module
@@ -32,7 +32,7 @@ to implement custom failure criteria and computation.
         :link: examples/index
         :link-type: doc
 
-        Demonstrates the use of PyDPF Composites for various workflows.
+        Demonstrates the use of PyDPF - Composites for various workflows.
 
     .. grid-item-card:: :octicon:`file-code` API reference
         :link: api/index
@@ -54,7 +54,7 @@ Lay-up files from ACP are optional and only required for some advanced operation
 Key features
 ''''''''''''
 
-Here are some key features of PyDPF Composites:
+Here are some key features of PyDPF - Composites:
 
 * Postprocessing of layered shell and solid elements. MAPDL models as well as models preprocessed with ACP are supported.
 * Failure criteria evaluation as shown in :ref:`Composite failure analysis <sphx_glr_examples_gallery_examples_001_failure_operator_example.py>`.

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -4,7 +4,7 @@ Getting started
 Installation
 ^^^^^^^^^^^^
 
-PyDPF Composites supports Ansys version 2023 R1 and later. Make sure you have a licensed copy of Ansys installed. See
+PyDPF - Composites supports Ansys version 2023 R1 and later. Make sure you have a licensed copy of Ansys installed. See
 :ref:`Compatibility` to understand which ``ansys-dpf-composites`` version corresponds to which Ansys version.
 
 Install the ``ansys-dpf-composites`` package with ``pip``:

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -1,7 +1,7 @@
 ANSYS
 Ansys
 ansys
-PyDPF Composites
+PyDPF - Composites
 accessor
 interlaminar
 postprocess

--- a/examples/001_failure_operator_example.py
+++ b/examples/001_failure_operator_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/002_sampling_point_example.py
+++ b/examples/002_sampling_point_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/003_short_fiber_example.py
+++ b/examples/003_short_fiber_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/004_get_material_properties_example.py
+++ b/examples/004_get_material_properties_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/005_get_layup_properties_example.py
+++ b/examples/005_get_layup_properties_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/006_filter_composite_data_example.py
+++ b/examples/006_filter_composite_data_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/007_interlaminar_normal_stress_example.py
+++ b/examples/007_interlaminar_normal_stress_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/008_assembly_example.py
+++ b/examples/008_assembly_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/009_short_fiber_orientation_tensor.py
+++ b/examples/009_short_fiber_orientation_tensor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/010_harmonic_example.py
+++ b/examples/010_harmonic_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/011_rst_workflow.py
+++ b/examples/011_rst_workflow.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/012_fatigue_example.py
+++ b/examples/012_fatigue_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/013_thermal_example.py
+++ b/examples/013_thermal_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/014_cyclic_symmetry_example.py
+++ b/examples/014_cyclic_symmetry_example.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -83,7 +83,7 @@ irf_field.plot()
 # %%
 # Plot ply-wise stresses
 # ~~~~~~~~~~~~~~~~~~~~~~
-# All functions in PyDPF Composites can be used to
+# All functions in PyDPF - Composites can be used to
 # postprocess the initial (original) sector.
 
 rst_stream = composite_model.core_model.metadata.streams_provider

--- a/examples/099_dpf_composite_failure_workflow.py
+++ b/examples/099_dpf_composite_failure_workflow.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -4,4 +4,4 @@
 ========
 Examples
 ========
-These examples demonstrate the behavior and usage of PyDPF Composites.
+These examples demonstrate the behavior and usage of PyDPF - Composites.

--- a/src/ansys/dpf/composites/__init__.py
+++ b/src/ansys/dpf/composites/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/_composite_model_factory.py
+++ b/src/ansys/dpf/composites/_composite_model_factory.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/_composite_model_impl.py
+++ b/src/ansys/dpf/composites/_composite_model_impl.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/_composite_model_impl_2023r2.py
+++ b/src/ansys/dpf/composites/_composite_model_impl_2023r2.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/_composite_model_impl_helpers.py
+++ b/src/ansys/dpf/composites/_composite_model_impl_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/_indexer.py
+++ b/src/ansys/dpf/composites/_indexer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/_sampling_point_helpers.py
+++ b/src/ansys/dpf/composites/_sampling_point_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/_typing_helper.py
+++ b/src/ansys/dpf/composites/_typing_helper.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/composite_model.py
+++ b/src/ansys/dpf/composites/composite_model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/composite_scope.py
+++ b/src/ansys/dpf/composites/composite_scope.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/constants.py
+++ b/src/ansys/dpf/composites/constants.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Collection of constants used across PyDPF Composites."""
+"""Collection of constants used across PyDPF - Composites."""
 from enum import IntEnum
 
 __all__ = (

--- a/src/ansys/dpf/composites/data_sources.py
+++ b/src/ansys/dpf/composites/data_sources.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/example_helper/__init__.py
+++ b/src/ansys/dpf/composites/example_helper/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/__init__.py
+++ b/src/ansys/dpf/composites/failure_criteria/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_combined_failure_criterion.py
+++ b/src/ansys/dpf/composites/failure_criteria/_combined_failure_criterion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_core_failure.py
+++ b/src/ansys/dpf/composites/failure_criteria/_core_failure.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_cuntze.py
+++ b/src/ansys/dpf/composites/failure_criteria/_cuntze.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_face_sheet_wrinkling.py
+++ b/src/ansys/dpf/composites/failure_criteria/_face_sheet_wrinkling.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_failure_criterion_base.py
+++ b/src/ansys/dpf/composites/failure_criteria/_failure_criterion_base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_failure_mode_enum.py
+++ b/src/ansys/dpf/composites/failure_criteria/_failure_mode_enum.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_hashin.py
+++ b/src/ansys/dpf/composites/failure_criteria/_hashin.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_hoffman.py
+++ b/src/ansys/dpf/composites/failure_criteria/_hoffman.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_larc.py
+++ b/src/ansys/dpf/composites/failure_criteria/_larc.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_max_strain.py
+++ b/src/ansys/dpf/composites/failure_criteria/_max_strain.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_max_stress.py
+++ b/src/ansys/dpf/composites/failure_criteria/_max_stress.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_puck.py
+++ b/src/ansys/dpf/composites/failure_criteria/_puck.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_quadratic_failure_criterion.py
+++ b/src/ansys/dpf/composites/failure_criteria/_quadratic_failure_criterion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_shear_crimping.py
+++ b/src/ansys/dpf/composites/failure_criteria/_shear_crimping.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_tsai_hill.py
+++ b/src/ansys/dpf/composites/failure_criteria/_tsai_hill.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_tsai_wu.py
+++ b/src/ansys/dpf/composites/failure_criteria/_tsai_wu.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/failure_criteria/_von_mises.py
+++ b/src/ansys/dpf/composites/failure_criteria/_von_mises.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/layup_info/__init__.py
+++ b/src/ansys/dpf/composites/layup_info/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/layup_info/_add_layup_info_to_mesh.py
+++ b/src/ansys/dpf/composites/layup_info/_add_layup_info_to_mesh.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/layup_info/_enums.py
+++ b/src/ansys/dpf/composites/layup_info/_enums.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/layup_info/_layup_info.py
+++ b/src/ansys/dpf/composites/layup_info/_layup_info.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/layup_info/_reference_surface.py
+++ b/src/ansys/dpf/composites/layup_info/_reference_surface.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/layup_info/material_operators.py
+++ b/src/ansys/dpf/composites/layup_info/material_operators.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/layup_info/material_properties.py
+++ b/src/ansys/dpf/composites/layup_info/material_properties.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/ply_wise_data.py
+++ b/src/ansys/dpf/composites/ply_wise_data.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/result_definition.py
+++ b/src/ansys/dpf/composites/result_definition.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/sampling_point.py
+++ b/src/ansys/dpf/composites/sampling_point.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/sampling_point_2023r2.py
+++ b/src/ansys/dpf/composites/sampling_point_2023r2.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/sampling_point_types.py
+++ b/src/ansys/dpf/composites/sampling_point_types.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/select_indices.py
+++ b/src/ansys/dpf/composites/select_indices.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/server_helpers/__init__.py
+++ b/src/ansys/dpf/composites/server_helpers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/server_helpers/_connect_to_or_start_server.py
+++ b/src/ansys/dpf/composites/server_helpers/_connect_to_or_start_server.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/server_helpers/_load_plugin.py
+++ b/src/ansys/dpf/composites/server_helpers/_load_plugin.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/server_helpers/_upload_files_to_server.py
+++ b/src/ansys/dpf/composites/server_helpers/_upload_files_to_server.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/server_helpers/_versions.py
+++ b/src/ansys/dpf/composites/server_helpers/_versions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/dpf/composites/unit_system.py
+++ b/src/ansys/dpf/composites/unit_system.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/basic_workflow_test.py
+++ b/tests/basic_workflow_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/composite_model_scoping_test.py
+++ b/tests/composite_model_scoping_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/composite_model_test.py
+++ b/tests/composite_model_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/element_info_output_all_element_types_test.py
+++ b/tests/element_info_output_all_element_types_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/element_info_test.py
+++ b/tests/element_info_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/combined_failure_criterion_test.py
+++ b/tests/failure_criteria/combined_failure_criterion_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/core_failure_test.py
+++ b/tests/failure_criteria/core_failure_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/cuntze_test.py
+++ b/tests/failure_criteria/cuntze_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/face_sheet_wrinkling_test.py
+++ b/tests/failure_criteria/face_sheet_wrinkling_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/hashin_test.py
+++ b/tests/failure_criteria/hashin_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/hoffman_test.py
+++ b/tests/failure_criteria/hoffman_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/larc_test.py
+++ b/tests/failure_criteria/larc_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/max_strain_criterion_test.py
+++ b/tests/failure_criteria/max_strain_criterion_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/max_stress_criterion_test.py
+++ b/tests/failure_criteria/max_stress_criterion_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/puck_test.py
+++ b/tests/failure_criteria/puck_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/shear_crimping_test.py
+++ b/tests/failure_criteria/shear_crimping_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/tsai_hill_test.py
+++ b/tests/failure_criteria/tsai_hill_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/tsai_wu_test.py
+++ b/tests/failure_criteria/tsai_wu_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/failure_criteria/von_mises_test.py
+++ b/tests/failure_criteria/von_mises_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/filter_layered_data_test.py
+++ b/tests/filter_layered_data_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/getting_started_test.py
+++ b/tests/getting_started_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/layup_properties_test.py
+++ b/tests/layup_properties_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/material_properties_test.py
+++ b/tests/material_properties_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/performance_test.py
+++ b/tests/performance_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/ply_wise_data_test.py
+++ b/tests/ply_wise_data_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/result_definition_test.py
+++ b/tests/result_definition_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/rst_only_workflow_test.py
+++ b/tests/rst_only_workflow_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/sampling_point_test.py
+++ b/tests/sampling_point_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #


### PR DESCRIPTION
Replace all instances of 'PyDPF Composites' with 'PyDPF - Composites', to be consistent with the naming of 'PyDPF - Core' and 'PyDPF - Post'.