### PR TITLE
Enable mesh property tests

### DIFF
--- a/tests/composite_model_scoping_test.py
+++ b/tests/composite_model_scoping_test.py
@@ -185,9 +185,15 @@ def test_composite_model_named_selection_and_ply_scope(dpf_server, data_files, d
     """Verify scoping by Named Selection in combination with plies."""
     composite_model = CompositeModel(data_files, server=dpf_server)
 
-    if distributed_rst:
+    #  if distributed_rst:
+    #     # Due to issue #856638
+    #     pytest.xfail("This test still fails even issue 856638 is resolved.")
+    if version_older_than(dpf_server, "8.0"):
         # Due to issue #856638
-        pytest.xfail("This test still fails even issue 856638 is resolved.")
+        pytest.xfail(
+            "The mesh property provider of DPF servers older than 8.0"
+            " does not support distributed RST."
+        )
 
     ply_ids = ["P1L1__woven_45.2", "P1L1__ud.2"]
     analysis_plies = get_all_analysis_ply_names(composite_model.get_mesh())

--- a/tests/composite_model_scoping_test.py
+++ b/tests/composite_model_scoping_test.py
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import pathlib
 from collections.abc import Sequence
+import pathlib
 
 import numpy as np
 import pytest
@@ -185,9 +185,9 @@ def test_composite_model_named_selection_and_ply_scope(dpf_server, data_files, d
     """Verify scoping by Named Selection in combination with plies."""
     composite_model = CompositeModel(data_files, server=dpf_server)
 
-    if version_older_than(dpf_server, "8.0"):
+    if distributed_rst:
         # Due to issue #856638
-        pytest.xfail("The mesh property provider operator does not yet support distributed RST.")
+        pytest.xfail("This test still fails even issue 856638 is resolved.")
 
     ply_ids = ["P1L1__woven_45.2", "P1L1__ud.2"]
     analysis_plies = get_all_analysis_ply_names(composite_model.get_mesh())

--- a/tests/composite_model_scoping_test.py
+++ b/tests/composite_model_scoping_test.py
@@ -63,10 +63,6 @@ def test_composite_model_element_scope(dpf_server, data_files):
 
 def test_composite_model_named_selection_scope(dpf_server, data_files, distributed_rst):
     """Ensure that the scoping by Named Selection is supported"""
-    if distributed_rst:
-        # TODO: remove once backend issue #856638 is resolved
-        pytest.xfail("The mesh property provider operator does not yet support distributed RST.")
-
     composite_model = CompositeModel(data_files, server=dpf_server)
 
     ns_name = "NS_ELEM"
@@ -172,10 +168,6 @@ def test_composite_model_ply_scope(dpf_server):
 
 def test_composite_model_named_selection_and_ply_scope(dpf_server, data_files, distributed_rst):
     """Verify scoping by Named Selection in combination with plies."""
-    if distributed_rst:
-        # TODO: remove once backend issue #856638 is resolved
-        pytest.xfail("The mesh property provider operator does not yet support distributed RST.")
-
     composite_model = CompositeModel(data_files, server=dpf_server)
 
     ns_name = "NS_ELEM"

--- a/tests/composite_model_scoping_test.py
+++ b/tests/composite_model_scoping_test.py
@@ -48,7 +48,7 @@ def get_scope(
 ) -> CompositeScope:
     if distributed_rst:
         # Named selection is missing in the distributed result
-        return CompositeScope(elements=[2, 3])
+        return CompositeScope(elements=[2, 3], plies=ply_ids)
     else:
         ns_name = "NS_ELEM"
         assert ns_name in composite_model.get_mesh().available_named_selections

--- a/tests/composite_model_scoping_test.py
+++ b/tests/composite_model_scoping_test.py
@@ -44,7 +44,7 @@ SEPARATOR = "::"
 
 
 def get_scope(
-    composite_model: CompositeModel, distributed_rst: bool, ply_ids: Sequence[str] = None
+    composite_model: CompositeModel, distributed_rst: bool, ply_ids: Sequence[str]
 ) -> CompositeScope:
     if distributed_rst:
         # Named selection is missing in the distributed result
@@ -87,7 +87,7 @@ def test_composite_model_named_selection_scope(dpf_server, data_files, distribut
     cfc = CombinedFailureCriterion("max stress", failure_criteria=[MaxStressCriterion()])
 
     failure_container = composite_model.evaluate_failure_criteria(
-        cfc, get_scope(composite_model, distributed_rst)
+        cfc, get_scope(composite_model, distributed_rst, [])
     )
     irfs = failure_container.get_field({FAILURE_LABEL: FailureOutput.FAILURE_VALUE})
     assert len(irfs.data) == 2

--- a/tests/composite_model_scoping_test.py
+++ b/tests/composite_model_scoping_test.py
@@ -81,7 +81,10 @@ def test_composite_model_named_selection_scope(dpf_server, data_files, distribut
 
     if version_older_than(dpf_server, "8.0"):
         # Due to issue #856638
-        pytest.xfail("The mesh property provider operator does not yet support distributed RST.")
+        pytest.xfail(
+            "The mesh property provider of DPF servers older than 8.0"
+            " does not support distributed RST."
+        )
 
     composite_model = CompositeModel(data_files, server=dpf_server)
     cfc = CombinedFailureCriterion("max stress", failure_criteria=[MaxStressCriterion()])
@@ -185,9 +188,6 @@ def test_composite_model_named_selection_and_ply_scope(dpf_server, data_files, d
     """Verify scoping by Named Selection in combination with plies."""
     composite_model = CompositeModel(data_files, server=dpf_server)
 
-    #  if distributed_rst:
-    #     # Due to issue #856638
-    #     pytest.xfail("This test still fails even issue 856638 is resolved.")
     if version_older_than(dpf_server, "8.0"):
         # Due to issue #856638
         pytest.xfail(

--- a/tests/composite_model_test.py
+++ b/tests/composite_model_test.py
@@ -55,7 +55,10 @@ SEPARATOR = "::"
 def test_basic_functionality_of_composite_model(dpf_server, data_files, distributed_rst):
     if version_older_than(dpf_server, "8.0"):
         # Due to issue #856638
-        pytest.xfail("The mesh property provider operator does not yet support distributed RST.")
+        pytest.xfail(
+            "The mesh property provider of DPF servers older than 8.0"
+            " does not support distributed RST."
+        )
 
     timer = Timer()
 

--- a/tests/composite_model_test.py
+++ b/tests/composite_model_test.py
@@ -53,6 +53,10 @@ SEPARATOR = "::"
 
 
 def test_basic_functionality_of_composite_model(dpf_server, data_files, distributed_rst):
+    if version_older_than(dpf_server, "8.0"):
+        # Due to issue #856638
+        pytest.xfail("The mesh property provider operator does not yet support distributed RST.")
+
     timer = Timer()
 
     composite_model = CompositeModel(data_files, server=dpf_server)

--- a/tests/composite_model_test.py
+++ b/tests/composite_model_test.py
@@ -53,10 +53,6 @@ SEPARATOR = "::"
 
 
 def test_basic_functionality_of_composite_model(dpf_server, data_files, distributed_rst):
-    if distributed_rst:
-        # TODO: remove once backend issue #856638 is resolved
-        pytest.xfail("The mesh property provider operator does not yet support distributed RST.")
-
     timer = Timer()
 
     composite_model = CompositeModel(data_files, server=dpf_server)

--- a/tests/rst_only_workflow_test.py
+++ b/tests/rst_only_workflow_test.py
@@ -48,10 +48,6 @@ SEPARATOR = "::"
 
 def test_composite_model_with_rst_only(dpf_server, data_files, distributed_rst):
     """Test features of the composite model with section data from the RST file only."""
-    if distributed_rst:
-        # TODO: remove once backend issue #856638 is resolved
-        pytest.xfail("The mesh property provider operator does not yet support distributed RST.")
-
     if version_older_than(dpf_server, "8.0"):
         pytest.xfail("Section data from RST is supported since server version 8.0 (2024 R2).")
 


### PR DESCRIPTION
Enable tests for the mesh property provider which were skipped due to ADO issue 856638. This issue was resolved a while ago.