### PR TITLE
update test matrix of the docker containers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # Owners will be requested for review when someone opens a PR.
-*       @greschd @janvonrickenbach @roosre
+*       @greschd @janvonrickenbach @roosre @sraimondi

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -76,10 +76,9 @@ jobs:
         # if other containers must be tested.
         run:  |
           docker pull ghcr.io/ansys/pydpf-composites:${{ env.CONTAINER_TAG }}
-          docker pull ghcr.io/ansys/pydpf-composites:2025r1_pre0
-          docker pull ghcr.io/ansys/pydpf-composites:2024r2_pre1
-          docker pull ghcr.io/ansys/pydpf-composites:2024r2_pre0
-          docker pull ghcr.io/ansys/pydpf-composites:2024r1_pre0
+          docker pull ghcr.io/ansys/pydpf-composites:2025r2
+          docker pull ghcr.io/ansys/pydpf-composites:2025r1
+          docker pull ghcr.io/ansys/pydpf-composites:2024r2
           docker pull ghcr.io/ansys/pydpf-composites:2024r1
           docker pull ghcr.io/ansys/pydpf-composites:2023r2_pre1
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,11 +32,10 @@ setenv =
 commands =
     poetry install -E test
     poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=latest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
-    poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2025r1_pre0 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
-    poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2024r2_pre1 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
-    poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2024r2_pre0 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
+    poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2025r2 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
+    poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2025r1 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
+    poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2024r2 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
     poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2024r1 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
-    poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2024r1_pre0 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
     poetry run pytest --reruns 1 --license-server={env:LICENSE_SERVER:} --image-tag=2023r2_pre1 {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {env:PYTEST_COV_APPEND_ARG:} {posargs:-vv}
 
 [testenv:test-minimal]


### PR DESCRIPTION
Add docker container 2025 R2 to the test matrix and remove previews and test only the major versions of the DPF server.