### PR TITLE
fix(release): use the GITHUB_TOKEN when releasing to GitHub

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -266,6 +266,7 @@ jobs:
         uses: ansys/actions/release-github@v9
         with:
           library-name: ${{ env.PACKAGE_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-deploy-stable:
     name: "Deploy stable documentation"


### PR DESCRIPTION
Fix the issues raised in https://github.com/ansys/pydpf-composites/actions/runs/15130369140/job/42544204612 by passing the `GITHUB_TOKEN` to the `release-github` action.