### PR TITLE
fix(doc): remove outdated options in conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -51,7 +51,6 @@ html_theme_options = {
         "json_url": f"https://{cname}/versions.json",
         "version_match": get_version_match(__version__),
     },
-    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
 }
 
 # Sphinx extensions


### PR DESCRIPTION
This pull-request removes an outdated configuration for the navigation bar in the `conf.py` file, ensuring the rendering of the search bar.