### PR TITLE
Fix bird strike example camera clipping

### DIFF
--- a/examples/016_lsdyna_bird_strike.py
+++ b/examples/016_lsdyna_bird_strike.py
@@ -162,7 +162,6 @@ for ply_name in ["P1L1__ModelingPly.1", "P3L2__ModelingPly.1"]:
         field_or_fields_container=elemental_values,
         deform_by=displacement,
         cpos=camera,
-        zoom="tight",
     )
 
 # %%
@@ -193,5 +192,4 @@ for ply_name in ["P1L1__ModelingPly.1", "P3L2__ModelingPly.1"]:
         field_or_fields_container=elemental_values,
         deform_by=displacement,
         cpos=camera,
-        zoom="tight",
     )


### PR DESCRIPTION
Fix the clipping of the plots when running the birdstrike example locally (also the 
camera orientation was wrong) by removing the `zoom='tight'` argument.

In the rendered documentation, adding / removing the argument doesn't seem to
have any effect.

This seems to be a somewhat known PyVista bug, see https://github.com/pyvista/pyvista/issues/3580

2026R1 hardening item 19.