### PR TITLE
Add dependabot cooldown of 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,15 @@ updates:
       dependencies:
         patterns:
           - "*" # Update all packages together
+    cooldown:
+      include:
+        - '*'
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      include:
+        - '*'
+      default-days: 7


### PR DESCRIPTION
Wait for 7 days before opening a PR for a newly released dependency version.

This reduces the supply chain attach risk for threats which are identified quickly after release.